### PR TITLE
ISPN-3971 Make it possible to deploy protostream in OSGI (Karaf)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>protostream</artifactId>
+    <packaging>bundle</packaging>
 
     <name>ProtoStream serializers for protobuf</name>
     <description>
@@ -111,6 +112,12 @@
 
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
+            </plugin>
+            
+            <plugin>
+               <groupId>org.apache.felix</groupId>
+               <artifactId>maven-bundle-plugin</artifactId>
+               <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
With this commit, it's possible to deploy protostream into Karaf successfully. The thing is that Manifest.mf must be properly generated and this is achieved with the bundle plugin.
