### PR TITLE
fix optional and field with a default value

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/MarshallerCodeGenerator.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/MarshallerCodeGenerator.java
@@ -465,7 +465,7 @@ final class MarshallerCodeGenerator {
       } else {
          iw.append("o.").append(createSetter(fieldMetadata, "v")).append(";\n");
       }
-      if (fieldMetadata.isRequired()) {
+      if (fieldMetadata.isRequired() || fieldMetadata.getDefaultValue() != null) {
          iw.append(makeFieldWasSetFlag(fieldMetadata)).append(" = true;\n");
       }
    }

--- a/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
+++ b/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
@@ -110,6 +110,7 @@ public class ProtoSchemaBuilderTest extends AbstractProtoStreamTest {
 
       TestClass testClass = new TestClass();
       testClass.surname = "test";
+      testClass.longField = 100L;
       testClass.testClass2 = new TestClass2();
       testClass.testClass2.address = "test address";
       bytes = ProtobufUtil.toWrappedByteArray(ctx, testClass);
@@ -117,6 +118,7 @@ public class ProtoSchemaBuilderTest extends AbstractProtoStreamTest {
       unmarshalled = ProtobufUtil.fromWrappedByteArray(ctx, bytes);
       assertTrue(unmarshalled instanceof TestClass);
       assertEquals("test", ((TestClass) unmarshalled).surname);
+      assertEquals(100L, ((TestClass) unmarshalled).longField);
       assertEquals("test address", ((TestClass) unmarshalled).testClass2.address);
    }
 


### PR DESCRIPTION
In the case of field optional and default value is specified, it seems would have been overwritten with default values.

For example, the following fields will be always the default value 23.

https://github.com/infinispan/protostream/blob/3.0.4.Final/core/src/test/java/org/infinispan/protostream/annotations/impl/testdomain/TestClass.java#L38

Code that is generated from this class, it seems it is also "__wasSet" by setting the value does not become true.
```java
   final org.infinispan.protostream.annotations.impl.testdomain.TestClass o = new org.infinispan.protostream.annotations.impl.testdomain.TestClass();
   boolean __wasSet$surname = false;
   boolean __wasSet$age = false;
   boolean __wasSet$color = false;
   java.util.LinkedList __c$ints = null;
   boolean __wasSet$x = false;
   boolean __wasSet$longField = false;
   boolean __wasSet$doubleField = false;
   boolean __wasSet$floatField = false;
   boolean done = false;
   while (!done) {
```

Here, true is not set.
```java
         case 8000:
            {
               long v = $2.readInt64();
               o.longField = v;
            }
            break;
```

Finally, I think we can become the default value.
```java
   if (!__wasSet$longField) {
      o.longField = 23L;
   }
```