### PR TITLE
IPROTO-67 Remove the class parameter from ProtoStreamWriter.writeEnum

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/MessageMarshaller.java
+++ b/core/src/main/java/org/infinispan/protostream/MessageMarshaller.java
@@ -138,7 +138,22 @@ public interface MessageMarshaller<T> extends BaseMarshaller<T> {
 
       <E> void writeObject(String fieldName, E value, Class<? extends E> clazz) throws IOException;
 
+      /**
+       * Writes an enum value. The third argument (the {@code class} was never used internally) so this variant is now
+       * deprecated.
+       *
+       * @deprecated replaced by {@link #writeEnum(String fieldName, E value)}
+       */
+      @Deprecated
       <E extends Enum<E>> void writeEnum(String fieldName, E value, Class<E> clazz) throws IOException;
+
+      /**
+       * Writes an enum value.
+       *
+       * @param fieldName the field name
+       * @param value     the enum value
+       */
+      <E extends Enum<E>> void writeEnum(String fieldName, E value) throws IOException;
 
       <E> void writeCollection(String fieldName, Collection<? super E> collection, Class<E> elementClass) throws IOException;
 

--- a/core/src/main/java/org/infinispan/protostream/impl/ProtoStreamWriterImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/ProtoStreamWriterImpl.java
@@ -471,7 +471,23 @@ final class ProtoStreamWriterImpl implements MessageMarshaller.ProtoStreamWriter
 
    @Override
    public <E extends Enum<E>> void writeEnum(String fieldName, E value, Class<E> clazz) throws IOException {
-      writeObject(fieldName, value, clazz);
+      writeEnum(fieldName, value);
+   }
+
+   @Override
+   public <E extends Enum<E>> void writeEnum(String fieldName, E value) throws IOException {
+      final FieldDescriptor fd = messageContext.marshallerDelegate.getFieldByName(fieldName);
+      if (fd.getType() != Type.ENUM) {
+         throw new IllegalArgumentException("Declared field type is not an enum : " + fd.getFullName());
+      }
+      checkFieldWrite(fd);
+      if (value == null) {
+         if (fd.isRequired()) {
+            throw new IllegalArgumentException("A required field cannot be null : " + fd.getFullName());
+         }
+         return;
+      }
+      writeEnum(fd, value);
    }
 
    private void writeMessage(FieldDescriptor fd, Object value, Class clazz) throws IOException {

--- a/core/src/test/java/org/infinispan/protostream/domain/marshallers/UserMarshaller.java
+++ b/core/src/test/java/org/infinispan/protostream/domain/marshallers/UserMarshaller.java
@@ -72,7 +72,7 @@ public class UserMarshaller implements MessageMarshaller<User> {
       writer.writeString("salutation", user.getSalutation());
       writer.writeCollection("addresses", user.getAddresses(), Address.class);
       writer.writeInt("age", user.getAge());
-      writer.writeEnum("gender", user.getGender(), User.Gender.class);
+      writer.writeEnum("gender", user.getGender());
       writer.writeString("notes", user.getNotes());
       writer.writeInstant("creationDate", user.getCreationDate());
       writer.writeInstant("passwordExpirationDate", user.getPasswordExpirationDate());

--- a/sample-domain-implementation/src/main/java/org/infinispan/protostream/sampledomain/marshallers/UserMarshaller.java
+++ b/sample-domain-implementation/src/main/java/org/infinispan/protostream/sampledomain/marshallers/UserMarshaller.java
@@ -70,7 +70,7 @@ public class UserMarshaller implements MessageMarshaller<User>, UnknownFieldSetH
       writer.writeString("salutation", user.getSalutation());
       writer.writeCollection("addresses", user.getAddresses(), Address.class);
       writer.writeInt("age", user.getAge());
-      writer.writeEnum("gender", user.getGender(), User.Gender.class);
+      writer.writeEnum("gender", user.getGender());
       writer.writeString("notes", user.getNotes());
       writer.writeInstant("creationDate", user.getCreationDate());
       writer.writeInstant("passwordExpirationDate", user.getPasswordExpirationDate());


### PR DESCRIPTION
* a deprecated method having a class parameter is still kept for backward compat

https://issues.jboss.org/browse/IPROTO-67