### PR TITLE
IPROTO-82 Useless warnings regarding undefined proto schema annotations

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/protostream/config/Configuration.java
@@ -34,6 +34,12 @@ public interface Configuration {
 
    interface AnnotationsConfig {
 
+      /**
+       * Should we log a warning every time we encounter an undefined documentation annotation? This is {@code true} by
+       * default.
+       */
+      boolean logUndefinedAnnotations();
+
       Map<String, AnnotationConfiguration> annotations();
 
       interface Builder {
@@ -52,6 +58,12 @@ public interface Configuration {
       Builder setLogOutOfSequenceReads(boolean logOutOfSequenceReads);
 
       Builder setLogOutOfSequenceWrites(boolean logOutOfSequenceWrites);
+
+      /**
+       * Should we log a warning every time we encounter an undefined documentation annotation? This is {@code true} by
+       * default.
+       */
+      Builder setLogUndefinedAnnotations(boolean logUndefinedAnnotations);
 
       AnnotationsConfig.Builder annotationsConfig();
 

--- a/core/src/main/java/org/infinispan/protostream/descriptors/Descriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/Descriptor.java
@@ -161,7 +161,7 @@ public final class Descriptor extends AnnotatedDescriptorImpl implements Generic
 
    @Override
    protected AnnotationConfiguration getAnnotationConfig(String annotationName) {
-      AnnotationConfiguration annotationConfiguration = fileDescriptor.configuration.annotationsConfig().annotations().get(annotationName);
+      AnnotationConfiguration annotationConfiguration = getAnnotationsConfig().annotations().get(annotationName);
       if (annotationConfiguration == null) {
          return null;
       }

--- a/core/src/main/java/org/infinispan/protostream/descriptors/EnumDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/EnumDescriptor.java
@@ -46,7 +46,7 @@ public final class EnumDescriptor extends AnnotatedDescriptorImpl implements Gen
 
    @Override
    protected AnnotationConfiguration getAnnotationConfig(String annotationName) {
-      AnnotationConfiguration annotationConfiguration = fileDescriptor.configuration.annotationsConfig().annotations().get(annotationName);
+      AnnotationConfiguration annotationConfiguration = getAnnotationsConfig().annotations().get(annotationName);
       if (annotationConfiguration == null) {
          return null;
       }

--- a/core/src/main/java/org/infinispan/protostream/descriptors/FieldDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FieldDescriptor.java
@@ -159,7 +159,7 @@ public final class FieldDescriptor extends AnnotatedDescriptorImpl implements An
 
    @Override
    protected AnnotationConfiguration getAnnotationConfig(String annotationName) {
-      AnnotationConfiguration annotationConfiguration = fileDescriptor.configuration.annotationsConfig().annotations().get(annotationName);
+      AnnotationConfiguration annotationConfiguration = getAnnotationsConfig().annotations().get(annotationName);
       if (annotationConfiguration == null) {
          return null;
       }

--- a/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
@@ -109,6 +109,13 @@ public final class FileDescriptor {
       status = parsingException != null ? Status.PARSING_ERROR : Status.UNRESOLVED;
    }
 
+   public Configuration getConfiguration() {
+      return configuration;
+   }
+
+   /**
+    * This method is not part of the public API. May be removed in future versions.
+    */
    public void setConfiguration(Configuration configuration) {
       this.configuration = configuration;
    }


### PR DESCRIPTION
* no longer emit this warning if there are no used defined annotations
* introduce AnnotationsConfig.logUndefinedAnnotations config flag to turn this off completely

https://issues.jboss.org/browse/IPROTO-82