### PR TITLE
IPROTO-81 SerializationContext.registerMarshaller should unregister t…

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/impl/SerializationContextImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/SerializationContextImpl.java
@@ -186,7 +186,10 @@ public final class SerializationContextImpl implements SerializationContext {
       if (existingDelegate != null) {
          marshallersByClass.remove(existingDelegate.getMarshaller().getJavaClass());
       }
-      marshallersByClass.put(marshaller.getJavaClass(), marshallerDelegate);
+      existingDelegate = marshallersByClass.put(marshaller.getJavaClass(), marshallerDelegate);
+      if (existingDelegate != null) {
+         marshallersByName.remove(existingDelegate.getMarshaller().getTypeName());
+      }
    }
 
    private BaseMarshallerDelegate<?> makeMarshallerDelegate(BaseMarshaller<?> marshaller) {


### PR DESCRIPTION
…he previous Java type (if any)

* and we also need to remove the previous Protobuf type mapping (if any)

https://issues.jboss.org/browse/IPROTO-81