### PR TITLE
IPROTO-135 Update to javassist 3.26.0-GA

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -121,7 +121,7 @@
         <version.jboss.logging.processor>2.1.0.Final</version.jboss.logging.processor>
         <version.log4j>1.2.17</version.log4j>
         <version.jboss.marshalling>2.0.9.Final</version.jboss.marshalling>
-        <version.javassist>3.24.1-GA</version.javassist>
+        <version.javassist>3.26.0-GA</version.javassist>
         <version.osgi>4.3.1</version.osgi>
         <version.commons-cli>1.2</version.commons-cli>
         <version.gson>2.8.5</version.gson>


### PR DESCRIPTION
Update to latest GA.

https://issues.redhat.com/browse/IPROTO-135