### PR TITLE
PROTO-167 Allow setter methods to be annotated with @ProtoField even …

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
@@ -435,9 +435,6 @@ public final class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                   if (method.getParameterTypes().length != 1) {
                      throw new ProtoSchemaBuilderException("Illegal setter method signature: " + method);
                   }
-                  if (factory != null) {
-                     throw new ProtoSchemaBuilderException("Setter methods should not be annotated with @ProtoField when @ProtoFactory is used by a class: " + method);
-                  }
                   setter = method;
                   getter = findGetter(propertyName, method.getParameterTypes()[0]);
                   getterReturnType = getter.getReturnType();


### PR DESCRIPTION
…when @ProtoFactory is used

* this was previously not allowed because we tried to not allow existence of setters at all
   and make all @ProtoFactory created objects immutable

https://issues.redhat.com/browse/IPROTO-167