### PR TITLE
IPROTO-137 Support Schema and Marshaller generation for external classes

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/ProtoBridgeFor.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/ProtoBridgeFor.java
@@ -1,0 +1,34 @@
+package org.infinispan.protostream.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// [anistor] TODO We also need a similar mechanism for enums.
+
+/**
+ * A marshalling bridge for another class that cannot be annotated. This class will handle marshalling for it by
+ * defining its schema via annotations.
+ * <p>
+ * The class bearing this annotation will have an annotated factory method for the marshalled class and annotated
+ * accessor methods for each field. These methods can be instance or static methods and their first argument must be
+ * the marshalled class. Annotations must be placed only on methods. Direct field annotation is not allowed.
+ * <p>
+ * This class must be thread-safe and stateless and must have an accessible no argument constructor. A single instance
+ * of it will be created per SerializationContext.
+ *
+ * @author anistor@redhat.com
+ * @since 4.4
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProtoBridgeFor {
+
+   /**
+    * The actual class being marshalled.
+    */
+   Class<?> value();
+}

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoTypeMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoTypeMetadata.java
@@ -88,6 +88,10 @@ public abstract class ProtoTypeMetadata implements HasProtoSchema {
       return canonicalName != null ? canonicalName : getAnnotatedClass().getName();
    }
 
+   public boolean isBridge() {
+      return false;
+   }
+
    /**
     * Indicates if this type comes from the currently processed/generated schema of from an external schema.
     */

--- a/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
+++ b/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
@@ -48,7 +48,9 @@ import org.infinispan.protostream.annotations.impl.testdomain.subpackage.TestCla
 import org.infinispan.protostream.descriptors.Descriptor;
 import org.infinispan.protostream.descriptors.EnumDescriptor;
 import org.infinispan.protostream.descriptors.FileDescriptor;
+import org.infinispan.protostream.domain.Address;
 import org.infinispan.protostream.domain.User;
+import org.infinispan.protostream.annotations.impl.testdomain.AddressBridge;
 import org.infinispan.protostream.impl.parser.SquareProtoParser;
 import org.infinispan.protostream.test.AbstractProtoStreamTest;
 import org.infinispan.protostream.test.ExpectedLogMessage;
@@ -1506,6 +1508,27 @@ public class ProtoSchemaBuilderTest extends AbstractProtoStreamTest {
       assertEquals(55, o.r);
       assertEquals(66, o.g);
       assertEquals(77, o.b);
+   }
+
+   @Test
+   public void testBridge() throws Exception {
+      SerializationContext ctx = createContext();
+      String schema = new ProtoSchemaBuilder()
+            .fileName("address.proto")
+            .addClass(AddressBridge.class)
+            .addClass(AddressBridge.AddressBridge2.class)
+            .build(ctx);
+
+      assertTrue(schema.contains("message Address"));
+
+      Address address = new Address("str", "po", 77, true);
+      byte[] bytes = ProtobufUtil.toWrappedByteArray(ctx, address);
+      Address o = ProtobufUtil.fromWrappedByteArray(ctx, bytes);
+
+      assertNotNull(o);
+      assertEquals("str", o.getStreet());
+      assertEquals("po", o.getPostCode());
+      assertEquals(77, o.getNumber());
    }
 
    static final class OuterClass {

--- a/core/src/test/java/org/infinispan/protostream/annotations/impl/testdomain/AddressBridge.java
+++ b/core/src/test/java/org/infinispan/protostream/annotations/impl/testdomain/AddressBridge.java
@@ -1,0 +1,79 @@
+package org.infinispan.protostream.annotations.impl.testdomain;
+
+import org.infinispan.protostream.annotations.ProtoBridgeFor;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+import org.infinispan.protostream.annotations.ProtoReserved;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+import org.infinispan.protostream.domain.Address;
+
+/**
+ * @author anistor@redhat.com
+ * @since 4.4
+ */
+@ProtoName("Address")
+@ProtoBridgeFor(Address.class)
+public class AddressBridge {
+
+   //todo [anistor] when setters are present, allow factory with 0 args
+   @ProtoFactory
+   public Address create(String street, Integer number, String postCode) {
+      return new Address(street, postCode, number);
+   }
+
+   @ProtoField(number = 1)
+   public String getStreet(Address a) {
+      return a.getStreet();
+   }
+
+   public void setStreet(Address a, String street) {
+      a.setStreet(street);
+   }
+
+   @ProtoField(2)
+   public String getPostCode(Address a) {
+      return a.getPostCode();
+   }
+
+   public void setPostCode(Address a, String postCode) {
+      a.setPostCode(postCode);
+   }
+
+   @ProtoField(number = 3, required = true)
+   public Integer getNumber(Address a) {
+      return a.getNumber();
+   }
+
+   public void setNumber(Address a, Integer number) {
+      a.setNumber(number);
+   }
+
+   // A funny case. A bridge nested inside a bridge should work just fine!
+   @ProtoName("Address2")
+   @ProtoReserved(numbers = {6, 99})
+   @ProtoTypeId(666)
+   @ProtoBridgeFor(Address.class)
+   public static class AddressBridge2 {
+
+      @ProtoFactory
+      public Address create(String street, Integer number, String postCode) {
+         return new Address(street, postCode, number);
+      }
+
+      @ProtoField(number = 1, name = "str")
+      public String getStreet(Address a) {
+         return a.getStreet();
+      }
+
+      @ProtoField(2)
+      public String getPostCode(Address a) {
+         return a.getPostCode();
+      }
+
+      @ProtoField(number = 3, required = true)
+      public Integer getNumber(Address a) {
+         return a.getNumber();
+      }
+   }
+}

--- a/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/AnnotationProcessorCompilationTest.java
+++ b/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/AnnotationProcessorCompilationTest.java
@@ -136,6 +136,17 @@ public class AnnotationProcessorCompilationTest {
       assertFileContains(schemaFile, "message InnerMessage4");
    }
 
+   @Test
+   public void testBridge() {
+      Compilation compilation = compile("org/infinispan/protostream/integrationtests/processor/MarshallExternals.java");
+      assertThat(compilation).succeededWithoutWarnings();
+      assertTrue(compilation.generatedFile(SOURCE_OUTPUT, "test_marshall_externals/TestInitializerImpl.java").isPresent());
+
+      Optional<JavaFileObject> schemaFile = compilation.generatedFile(CLASS_OUTPUT, "TestInitializer.proto");
+      assertTrue(schemaFile.isPresent());
+      assertFileContains(schemaFile, "message Address");
+   }
+
    /**
     * Asserts that the file contains a given expected string.
     */

--- a/integrationtests/src/test/resources/org/infinispan/protostream/integrationtests/processor/MarshallExternals.java
+++ b/integrationtests/src/test/resources/org/infinispan/protostream/integrationtests/processor/MarshallExternals.java
@@ -1,0 +1,84 @@
+package test_marshall_externals;
+
+import org.infinispan.protostream.*;
+import org.infinispan.protostream.annotations.*;
+
+@AutoProtoSchemaBuilder(includeClasses = AddressBridge.class, schemaFilePath = "/")
+interface TestInitializer extends SerializationContextInitializer {
+}
+
+class Address {
+
+   private String street_;
+
+   private String postCode_;
+
+   private int number_;
+
+   public Address(String street_, String postCode_, int number_) {
+      this.street_ = street_;
+      this.postCode_ = postCode_;
+      this.number_ = number_;
+   }
+
+   public String getStreet_() {
+      return street_;
+   }
+
+   public void setStreet_(String street_) {
+      this.street_ = street_;
+   }
+
+   public String getPostCode_() {
+      return postCode_;
+   }
+
+   public void setPostCode_(String postCode_) {
+      this.postCode_ = postCode_;
+   }
+
+   public int getNumber_() {
+      return number_;
+   }
+
+   public void setNumber_(int number_) {
+      this.number_ = number_;
+   }
+}
+
+@ProtoName("Address")
+@ProtoBridgeFor(Address.class)
+class AddressBridge {
+
+   @ProtoFactory
+   public Address create(String street, Integer number, String postCode) {
+      return new Address(street, postCode, number);
+   }
+
+   @ProtoField(1)
+   public String getStreet(Address a) {
+      return a.getStreet_();
+   }
+
+   public void setStreet(Address a, String street) {
+      a.setStreet_(street);
+   }
+
+   @ProtoField(2)
+   public String getPostCode(Address a) {
+      return a.getPostCode_();
+   }
+
+   public void setPostCode(Address a, String postCode) {
+      a.setPostCode_(postCode);
+   }
+
+   @ProtoField(number = 3, required = true)
+   public Integer getNumber(Address a) {
+      return a.getNumber_();
+   }
+
+   public void setNumber(Address a, Integer number) {
+      a.setNumber_(number);
+   }
+}

--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AnnotatedClassScanner.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AnnotatedClassScanner.java
@@ -30,6 +30,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
 import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+import org.infinispan.protostream.annotations.ProtoBridgeFor;
 import org.infinispan.protostream.annotations.ProtoEnum;
 import org.infinispan.protostream.annotations.ProtoEnumValue;
 import org.infinispan.protostream.annotations.ProtoFactory;
@@ -164,6 +165,10 @@ final class AnnotatedClassScanner {
             visitProtoName(e);
          }
 
+         for (Element e : roundEnv.getElementsAnnotatedWith(ProtoBridgeFor.class)) {
+            visitProtoBridgeFor(e);
+         }
+
          for (Element e : roundEnv.getElementsAnnotatedWith(ProtoTypeId.class)) {
             visitProtoTypeId(e);
          }
@@ -233,6 +238,13 @@ final class AnnotatedClassScanner {
          throw new AnnotationProcessingException(e, "@ProtoEnumValue can only be applied to enum constants.");
       }
       collectClasses((TypeElement) enclosingElement);
+   }
+
+   private void visitProtoBridgeFor(Element e) {
+      if (e.getKind() != ElementKind.CLASS ) {
+         throw new AnnotationProcessingException(e, "@ProtoBridgeFor can only be applied to classes.");
+      }
+      collectClasses((TypeElement) e);
    }
 
    private void visitProtoTypeId(Element e) {

--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/CompileTimeImportedProtoTypeMetadata.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/CompileTimeImportedProtoTypeMetadata.java
@@ -58,6 +58,11 @@ final class CompileTimeImportedProtoTypeMetadata extends ProtoTypeMetadata {
    }
 
    @Override
+   public boolean isBridge() {
+      return protoTypeMetadata.isBridge();
+   }
+
+   @Override
    public String toString() {
       return "AnnotationBasedImportedProtoTypeMetadata{" +
             "name='" + name + '\'' +

--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/CompileTimeProtoMessageTypeMetadata.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/CompileTimeProtoMessageTypeMetadata.java
@@ -12,8 +12,8 @@ import org.infinispan.protostream.annotations.impl.types.XClass;
  */
 class CompileTimeProtoMessageTypeMetadata extends ProtoMessageTypeMetadata {
 
-   CompileTimeProtoMessageTypeMetadata(CompileTimeProtoSchemaGenerator protoSchemaGenerator, XClass annotatedClass) {
-      super(protoSchemaGenerator, annotatedClass);
+   CompileTimeProtoMessageTypeMetadata(CompileTimeProtoSchemaGenerator protoSchemaGenerator, XClass annotatedClass, XClass javaClass) {
+      super(protoSchemaGenerator, annotatedClass, javaClass);
    }
 
    @Override

--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/MarshallerSourceCodeGenerator.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/MarshallerSourceCodeGenerator.java
@@ -161,6 +161,10 @@ final class MarshallerSourceCodeGenerator extends AbstractMarshallerCodeGenerato
             .append(" {\n\n");
       iw.inc();
 
+      if (pmtm.isBridge()) {
+         addBridgeField(iw, pmtm);
+      }
+
       addMarshallerDelegateFields(iw, pmtm);
 
       iw.append("@Override\npublic Class<").append(pmtm.getJavaClassName()).append("> getJavaClass() { return ").append(pmtm.getJavaClassName()).append(".class; }\n\n");
@@ -190,6 +194,12 @@ final class MarshallerSourceCodeGenerator extends AbstractMarshallerCodeGenerato
       iw.append("}\n");
 
       emitSource(fqn, iw.toString(), pmtm);
+   }
+
+   private void addBridgeField(IndentWriter iw, ProtoMessageTypeMetadata messageTypeMetadata) {
+      iw.append("private final ").append(messageTypeMetadata.getAnnotatedClassName()).append(' ')
+            .append(BRIDGE_FIELD_NAME).append(" = new ")
+            .append(messageTypeMetadata.getAnnotatedClassName()).append("();\n\n");
    }
 
    /**


### PR DESCRIPTION
* introduce ProtoBridgeFor annotation to create annotation based
  marshallers for peer classes that cannot be annotated

https://issues.redhat.com/browse/IPROTO-137

NOTE: ```ProtoBridgeFor```used to be named ```ProtoMarshallerFor``` until just now. I'm open for other name suggestions. Since the next release is an Alpha we can have it as is and rename it sometime before final.