### PR TITLE
IPROTO-178 Canonical json to protobuf conversion writes TypeId as int…

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
+++ b/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
@@ -183,7 +183,7 @@ public final class WrappedMessage {
    public static final int WRAPPED_DESCRIPTOR_TYPE_ID = 19;
 
    /**
-    * @deprecated Use {@link #WRAPPED_DESCRIPTOR_TYPE_ID} instead.
+    * @deprecated Use {@link #WRAPPED_DESCRIPTOR_TYPE_ID} instead. This will be removed in ver. 5.
     */
    @Deprecated
    public static final int WRAPPED_DESCRIPTOR_ID = WRAPPED_DESCRIPTOR_TYPE_ID;

--- a/core/src/main/java/org/infinispan/protostream/impl/ByteArrayOutputStreamEx.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/ByteArrayOutputStreamEx.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
 /**
+ * Extends java.io.ByteArrayOutputStream and provides direct access to the internal buffer without copy.
+ *
  * @author anistor@redhat.com
  * @since 4.0
  */

--- a/core/src/test/java/org/infinispan/protostream/ProtobufParserTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufParserTest.java
@@ -78,7 +78,7 @@ public class ProtobufParserTest extends AbstractProtoStreamTest {
 
          @Override
          public void onStart(GenericDescriptor descriptor) {
-            log.debugf("onStart %s" + descriptor);
+            log.debugf("onStart %s", descriptor);
          }
 
          @Override


### PR DESCRIPTION
…32 instead of uint32

* IPROTO-116 changed type id from int32 to uint32 but the change
 was not correctly propagated in all places

https://issues.redhat.com/browse/IPROTO-178