### PR TITLE
IPROTO-208 Primitive types in proto files should not be case insensitive

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/descriptors/FieldDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FieldDescriptor.java
@@ -35,15 +35,16 @@ public final class FieldDescriptor extends AnnotatedDescriptorImpl implements An
 
    private FieldDescriptor(Builder builder) {
       super(builder.name, null, builder.documentation);
-      this.number = builder.number;
-      this.label = builder.label;
-      this.options = unmodifiableList(builder.options);
+      number = builder.number;
+      label = builder.label;
+      options = unmodifiableList(builder.options);
       for (Option opt : options) {
          optionByName.put(opt.getName(), opt.getValue());
       }
-      this.typeName = builder.typeName;
-      this.defaultValue = builder.defaultValue;
-      this.isExtension = builder.isExtension;
+      typeName = builder.typeName;
+      type = Type.primitiveFromString(typeName);
+      defaultValue = builder.defaultValue;
+      isExtension = builder.isExtension;
    }
 
    public int getNumber() {
@@ -56,10 +57,6 @@ public final class FieldDescriptor extends AnnotatedDescriptorImpl implements An
 
    public Type getType() {
       return type;
-   }
-
-   void setType(Type type) {
-      this.type = type;
    }
 
    public Descriptor getMessageType() {
@@ -232,14 +229,7 @@ public final class FieldDescriptor extends AnnotatedDescriptorImpl implements An
       }
 
       public FieldDescriptor build() {
-         FieldDescriptor fieldDescriptor = new FieldDescriptor(this);
-         try {
-            Type fieldType = Type.valueOf(typeName.toUpperCase());
-            fieldDescriptor.setType(fieldType);
-         } catch (IllegalArgumentException ignored) {
-            // TODO [anistor] This (harmless exception) happens because typeName is not a primitive but a user defined type. A nicer validation would be better.
-         }
-         return fieldDescriptor;
+         return new FieldDescriptor(this);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
@@ -333,7 +333,10 @@ public final class FileDescriptor {
 
    private void resolveFieldTypes(Descriptor descriptor) {
       for (FieldDescriptor fieldDescriptor : descriptor.getFields()) {
-         if (fieldDescriptor.getType() == null) {
+         if (fieldDescriptor.getType() == null ||
+               fieldDescriptor.getType() == Type.GROUP ||
+               fieldDescriptor.getType() == Type.MESSAGE ||
+               fieldDescriptor.getType() == Type.ENUM) {
             GenericDescriptor res = searchType(fieldDescriptor.getTypeName(), descriptor);
             if (res instanceof EnumDescriptor) {
                fieldDescriptor.setEnumType((EnumDescriptor) res);

--- a/core/src/main/java/org/infinispan/protostream/descriptors/Type.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/Type.java
@@ -2,7 +2,7 @@ package org.infinispan.protostream.descriptors;
 
 /**
  * Type of a field in Protobuf, can be any value defined in <a href="https://developers.google.com/protocol-buffers/docs/proto3#scalar">https://developers.google.com/protocol-buffers/docs/proto3#scalar</a>
- * or a message or an enum.
+ * or a group, message and enum.
  *
  * @author gustavonalle
  * @since 2.0
@@ -52,6 +52,47 @@ public enum Type {
    Type(JavaType javaType, WireType wireType) {
       this.javaType = javaType;
       this.wireType = wireType;
+   }
+
+   /**
+    * If the type name is a primitive, it returns the corresponding enum constant, otherwise it returns {@code null}.
+    */
+   public static Type primitiveFromString(String typeName) {
+      switch (typeName) {
+         case "double":
+            return DOUBLE;
+         case "float":
+            return FLOAT;
+         case "int64":
+            return INT64;
+         case "uint64":
+            return UINT64;
+         case "sint64":
+            return SINT64;
+         case "fixed64":
+            return FIXED64;
+         case "sfixed64":
+            return SFIXED64;
+         case "int32":
+            return INT32;
+         case "uint32":
+            return UINT32;
+         case "sint32":
+            return SINT32;
+         case "fixed32":
+            return FIXED32;
+         case "sfixed32":
+            return SFIXED32;
+         case "bool":
+            return BOOL;
+         case "string":
+            return STRING;
+         case "bytes":
+            return BYTES;
+         default:
+            // unknown type, not a primitive for sure
+            return null;
+      }
    }
 
    public JavaType getJavaType() {

--- a/core/src/test/java/org/infinispan/protostream/impl/TopLevelArrayTest.java
+++ b/core/src/test/java/org/infinispan/protostream/impl/TopLevelArrayTest.java
@@ -149,7 +149,7 @@ public class TopLevelArrayTest {
             "}\n" +
             "/** @TypeId(75001) */\n" +
             "message MyMessage {\n" +
-            "   optional String field1 = 1;\n" +
+            "   optional string field1 = 1;\n" +
             "}\n";
 
       FileDescriptorSource fileDescriptorSource = new FileDescriptorSource()


### PR DESCRIPTION
* Type.valueOf(typeName.toUpperCase()) was a huge mistake

https://issues.redhat.com/browse/IPROTO-208