### PR TITLE
Added buffer access to TagReader

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/TagReader.java
+++ b/core/src/main/java/org/infinispan/protostream/TagReader.java
@@ -1,6 +1,7 @@
 package org.infinispan.protostream;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 /**
@@ -84,4 +85,25 @@ public interface TagReader extends RawProtoStreamReader {
     * Returns back to a previous limit returned by pushLimit.
     */
    void popLimit(int oldLimit);
+
+   /** 
+    * Returns the full buffer array allowing an alternative protobuf parser to be used in marshallers,
+    * and at the root message level. This should not be mixed with the other tag reader read***() 
+    * methods, or else an IllegalStateException will be thrown. Therefore you cannot mix protostream
+    * annotated models with other parsers reading the raw payload array. 
+    */
+   byte[] fullBufferArray() throws IOException;
+
+   /** 
+    * Returns the input stream allowing an alternative protobuf parser to be used in marshallers,
+    * and at the root message level. This should not be mixed with the other tag reader read***() 
+    * methods, or else an IllegalStateException will be thrown. Therefore you cannot mix protostream
+    * annotated models with other parsers reading the raw payload input stream.  
+    */
+   InputStream fullBufferInputStream() throws IOException;
+
+   /**
+    * @return Returns true if the original payload is InputStream based.
+    */
+   boolean isInputStream(); 
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/TagReaderImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/TagReaderImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.protostream.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.BufferUnderflowException;
@@ -243,6 +244,36 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       return this;
    }
 
+
+   @Override
+   public byte[] fullBufferArray() throws IOException {
+      checkBufferUnused("fullBufferArray");
+      
+      return decoder.getBufferArray();
+   }
+
+   @Override
+   public InputStream fullBufferInputStream() throws IOException {
+      checkBufferUnused("fullBufferInputStream");
+      
+      if (isInputStream()) {
+         return ((InputStreamDecoder)decoder).getInputStream();
+      } else {
+         return new ByteArrayInputStream(decoder.getBufferArray());
+      }
+   }
+
+   private void checkBufferUnused(String methodName) {
+      if (decoder.getPos() > 0) {
+         throw new IllegalStateException(methodName + " in marshaller can only be used on an unprocessed buffer");
+      }
+   }
+
+   @Override
+   public boolean isInputStream() {
+      return (decoder instanceof InputStreamDecoder);
+   }
+
    /**
     * @deprecated this will be removed in 5.0 together with {@link org.infinispan.protostream.MessageMarshaller}
     */
@@ -263,6 +294,12 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       protected int globalLimit = Integer.MAX_VALUE;
 
       protected int lastTag;
+
+      abstract int getEnd();
+
+      abstract int getPos();
+
+      abstract byte[] getBufferArray() throws IOException;
 
       abstract boolean isAtEnd() throws IOException;
 
@@ -432,6 +469,21 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
 
       private void adjustEnd() {
          end = stop - start > limit ? start + limit : stop;
+      }
+
+      @Override
+      int getEnd() {
+         return end;
+      }
+
+      @Override
+      int getPos() {
+         return pos;
+      }
+
+      @Override
+      byte[] getBufferArray() throws IOException {
+         return array;
       }
 
       @Override
@@ -632,6 +684,22 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       private void adjustEnd() {
          end = stop - start > limit ? start + limit : stop;
       }
+
+      @Override
+      int getEnd() {
+         return end;
+      }
+
+      @Override
+      int getPos() {
+         return buf.position() - start;
+      }
+
+      @Override
+      byte[] getBufferArray() throws IOException {
+         return buf.array();
+      }
+      
 
       @Override
       boolean isAtEnd() {
@@ -977,6 +1045,26 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       }
 
       @Override
+      int getEnd() {
+         return end;
+      }
+
+      @Override
+      int getPos() {
+         return pos;
+      }
+
+      @Override
+      byte[] getBufferArray() throws IOException {
+         fillBuffer(buf.length);
+         return buf;
+      }
+
+      InputStream getInputStream() {
+         return in;
+      }
+
+      @Override
       boolean isAtEnd() throws IOException {
          return pos == end && !tryFillBuffer(1);
       }
@@ -1161,4 +1249,5 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
          }
       }
    }
+
 }

--- a/core/src/test/java/org/infinispan/protostream/impl/FullBufferReadTest.java
+++ b/core/src/test/java/org/infinispan/protostream/impl/FullBufferReadTest.java
@@ -1,0 +1,239 @@
+package org.infinispan.protostream.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.infinispan.protostream.BaseMarshaller;
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.ProtobufTagMarshaller;
+import org.infinispan.protostream.ProtobufTagMarshaller.ReadContext;
+import org.infinispan.protostream.ProtobufTagMarshaller.WriteContext;
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContext.MarshallerProvider;
+import org.infinispan.protostream.TagReader;
+import org.infinispan.protostream.TagWriter;
+import org.junit.Test;
+
+
+public class FullBufferReadTest {
+
+   private SerializationContext createContext() {
+      return ProtobufUtil.newSerializationContext();
+   }
+
+   @Test
+   public void testFullArrayMarshaller() throws Exception {
+      SerializationContext ctx = createContext();
+
+      FileDescriptorSource fileDescriptorSource = new FileDescriptorSource().addProtoFile("file.proto", file);
+      ctx.registerProtoFiles(fileDescriptorSource);
+       
+      class MockMarshallerFuncs implements MarshallerFuncs<X> {
+         public byte[] actualBytes = null;
+         public boolean isInputStream = false;
+
+         @Override
+         public X read(ReadContext rc) throws IOException {
+            TagReader r = rc.getReader();
+            isInputStream = r.isInputStream();
+            actualBytes = r.fullBufferArray();   
+            return null;
+         }
+
+         @Override
+         public void write(WriteContext wc, X p) throws IOException {
+            TagWriter w = wc.getWriter();
+            w.writeInt32(1, p.f1);
+            w.writeInt64(2, p.f2); 
+         }
+      }
+      MockMarshallerFuncs mockMarshallerFuncs = new MockMarshallerFuncs();
+          
+      ctx.registerMarshallerProvider(new MockProtobufMarshaller<>(X.class, "test.X", mockMarshallerFuncs));
+      
+      byte[] fullMsgBytes = ProtobufUtil.toWrappedByteArray(ctx, new X(1234, 4321L));
+            
+      ProtobufUtil.fromWrappedByteArray(ctx, fullMsgBytes);
+
+      assertNotNull(mockMarshallerFuncs.actualBytes);
+      assertEquals(6, mockMarshallerFuncs.actualBytes.length);
+      assertFalse(mockMarshallerFuncs.isInputStream);
+
+      byte[] expectedBytes = { 8, -46, 9, 16, -31, 33 };
+      assertNotNull(expectedBytes);
+      assertTrue(Arrays.equals(mockMarshallerFuncs.actualBytes, expectedBytes));
+   }
+
+   @Test
+   public void testFullArrayInputStreamMarshaller() throws Exception {
+      SerializationContext ctx = createContext();
+
+      FileDescriptorSource fileDescriptorSource = new FileDescriptorSource().addProtoFile("file.proto", file);
+      ctx.registerProtoFiles(fileDescriptorSource);
+       
+      class MockMarshallerFuncs implements MarshallerFuncs<X> {
+         public InputStream actualStream = null;
+         public boolean isInputStream = false;
+
+         @Override
+         public X read(ReadContext rc) throws IOException {
+            TagReader r = rc.getReader();
+            isInputStream = r.isInputStream();
+            actualStream = r.fullBufferInputStream();
+            return null;
+         }
+
+         @Override
+         public void write(WriteContext wc, X p) throws IOException {
+            TagWriter w = wc.getWriter();
+            w.writeInt32(1, p.f1);
+            w.writeInt64(2, p.f2); 
+         }
+      }
+      MockMarshallerFuncs mockMarshallerFuncs = new MockMarshallerFuncs();
+          
+      ctx.registerMarshallerProvider(new MockProtobufMarshaller<>(X.class, "test.X", mockMarshallerFuncs));
+      
+      byte[] fullMsgBytes = ProtobufUtil.toWrappedByteArray(ctx, new X(1234, 4321L));
+      InputStream in = new ByteArrayInputStream(fullMsgBytes);      
+
+      ProtobufUtil.fromWrappedStream(ctx, in);
+
+      assertNotNull(mockMarshallerFuncs.actualStream);
+      assertEquals(6, mockMarshallerFuncs.actualStream.available());
+      //assertTrue(mockMarshallerFuncs.isInputStream); // Currently always false - the InputStream appears to be converted to a byte array decoder after WrappedMessage processed
+
+      byte[] actualBytes = new byte[mockMarshallerFuncs.actualStream.available()];
+      mockMarshallerFuncs.actualStream.read(actualBytes);
+
+      byte[] expectedBytes = { 8, -46, 9, 16, -31, 33 };
+      assertNotNull(expectedBytes);
+      assertTrue(Arrays.equals(actualBytes, expectedBytes));
+   }
+
+   @Test
+   public void illegalStateExceptionOnMixingReadWithFullBuffer() throws Exception {
+      SerializationContext ctx = createContext();
+
+      FileDescriptorSource fileDescriptorSource = new FileDescriptorSource().addProtoFile("file.proto", file);
+      ctx.registerProtoFiles(fileDescriptorSource);
+       
+      class MockMarshallerFuncs implements MarshallerFuncs<X> {
+         public byte[] actualBytes = null;
+
+         @Override
+         public X read(ReadContext rc) throws IOException {
+            TagReader r = rc.getReader();
+            r.readTag(); // calling any tag or field read prior to fullBufferArray should call IllegalStateException
+            actualBytes = r.fullBufferArray();   
+            return null;
+         }
+
+         @Override
+         public void write(WriteContext wc, X p) throws IOException {
+            TagWriter w = wc.getWriter();
+            w.writeInt32(1, p.f1);
+            w.writeInt64(2, p.f2); 
+         }
+      }
+      MockMarshallerFuncs mockMarshallerFuncs = new MockMarshallerFuncs();
+          
+      ctx.registerMarshallerProvider(new MockProtobufMarshaller<>(X.class, "test.X", mockMarshallerFuncs));
+      
+      byte[] fullMsgBytes = ProtobufUtil.toWrappedByteArray(ctx, new X(1234, 4321L));
+      
+      try {
+         ProtobufUtil.fromWrappedByteArray(ctx, fullMsgBytes);
+         fail("IllegalStateException expected");
+      } catch (IllegalStateException e) {
+         assertEquals("fullBufferArray in marshaller can only be used on an unprocessed buffer", e.getMessage());         
+         assertNull(mockMarshallerFuncs.actualBytes);
+      }
+   }
+
+   /** Test Support **/
+
+   private String file = "package test;\n" +
+      "message X {\n" +
+      "   optional int32 f1 = 1;\n" +
+      "   optional int64 f2 = 2;\n" +
+      "}";
+
+   private class X {
+      Integer f1;
+      Long f2;
+      private X(Integer f1, Long f2) {
+         this.f1 = f1;
+         this.f2 = f2;
+      }
+   }
+
+   private interface MarshallerFuncs<P> {
+      P read(ReadContext rc) throws IOException;
+      void write(WriteContext wc, P p) throws IOException;
+   }
+ 
+   private class MockProtobufMarshaller<P> implements MarshallerProvider {
+      private Class<? extends P> clazz;
+      private String typeName; 
+      private MarshallerFuncs<P> marshallerFuncs;
+
+      MockProtobufMarshaller(Class<? extends P> clazz, String typeName, MarshallerFuncs<P> marshallerFuncs) {
+         this.clazz = clazz;
+         this.typeName = typeName;
+         this.marshallerFuncs = marshallerFuncs;
+      }
+
+      @Override
+      public BaseMarshaller<?> getMarshaller(String typeName) {
+         if (typeName.equals(typeName)) {
+            return makeMarshaller();
+         }
+         return null;
+      }
+
+      @Override
+      public BaseMarshaller<?> getMarshaller(Class<?> javaClass) {
+         if (javaClass == clazz) {
+            return makeMarshaller();
+         }
+         return null;
+      }
+
+      private BaseMarshaller<?> makeMarshaller() {
+         return new ProtobufTagMarshaller<P>() {
+
+            @Override
+            public P read(ReadContext ctx) throws IOException {
+               return marshallerFuncs.read(ctx);
+            }
+
+            @Override
+            public void write(WriteContext ctx, P x) throws IOException {
+               marshallerFuncs.write(ctx, x);
+            }
+
+            @Override
+            public Class<? extends P> getJavaClass() {
+               return clazz;
+            }
+
+            @Override
+            public String getTypeName() {
+               return typeName;
+            }
+         };
+      }      
+   }
+
+}


### PR DESCRIPTION
Exposing the bufferArray/InputStream on the TagReader interface will open the ability to use alternative frameworks for reading from infinispan, such as protobuf-java. Writing is already possible. For applications with many complex models, this will prevent the need to rebind to the protostream specific classes, and push/pull protobuf straight from other sources into the cache/grid. For large objects, the InputStream was also exposed.

The limitation is that proto messages in a single key:value pair can't mix accessing the full buffer array, with a protostream customer marshaller, nor protostream annotated auto objects. The entire payload of the WrappedMessage is read. Checks were added to the enhancement to prevent mixing, and make it clear to the user through an IllegalStateException, and comments on the TagReader interface. 

Tests were added for the happy path with the byte[] and InputStream, and a failure test for the mixing of marshalling modes. 

With this addition, a client can create a generic protobuf marshaller for existing protobuf-java classes using [1] and a context initializer like [2]. 

[1] 
```
public class GenericProtobufMarshaller<T extends AbstractMessage> implements ProtobufTagMarshaller<T> {
    private static final transient Logger log = LoggerFactory.getLogger(GenericProtobufMarshaller.class);

    private final Class<? extends T> javaClass;
    private final String typeName;
    private final ByteArrayParseFunction<byte[], T> parseFromMethod;

    public GenericProtobufMarshaller(
        final Class<? extends T> javaClass, 
        final String typeName, 
        ByteArrayParseFunction<byte[], T> parseFromMethod) 
    {
        this.javaClass = javaClass;
        this.typeName = typeName;
        this.parseFromMethod = parseFromMethod;
    }

    @Override
    public Class<? extends T> getJavaClass() {
        return javaClass;
    }

    @Override
    public String getTypeName() {
        return typeName;
    }

    @Override
    public T read(ReadContext ctx) throws IOException {
        TagReader reader = ctx.getReader();
                       
        byte[] rawBytes = reader.fullBufferArray();
        T t = parseFromMethod.apply(rawBytes);
        
        return t;
    }

    @Override
    public void write(WriteContext ctx, T t) throws IOException {
        byte[] tBytes = t.toByteArray();
        log.info("writing bytes: {}", tBytes);

        TagWriter out = ctx.getWriter();
        out.writeRawBytes(tBytes, 0, tBytes.length);
    }

    @FunctionalInterface
    public interface ByteArrayParseFunction<T, R> {
        R apply(T rawBytes) throws InvalidProtocolBufferException;
    }

}
```

[2]
```
public class MySerializationContextInitializer implements SerializationContextInitializer {
...
   @Override
    public void registerMarshallers(SerializationContext ctx) {
        ctx.registerMarshaller(new GenericProtobufMarshaller<>(Payment.class, "realtimepayments.Payment", Payment::parseFrom));  
        ctx.registerMarshaller(new GenericProtobufMarshaller<>(Payer.class, "realtimepayments.Payer", Payer::parseFrom));          
        ctx.registerMarshaller(new GenericProtobufMarshaller<>(Payee.class, "realtimepayments.Payee", Payee::parseFrom));       
        ctx.registerMarshaller(new GenericProtobufMarshaller<>(Transaction.class, "realtimepayments.Transaction", Transaction::parseFrom));
    }
...
}
```