### PR TITLE
IPROTO-228 Remove temporary buffers when marshalling objects

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
+++ b/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
@@ -144,13 +144,13 @@ public final class ProtobufUtil {
 
    public static byte[] toWrappedByteArray(ImmutableSerializationContext ctx, Object t, int bufferSize) throws IOException {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(bufferSize);
-      WrappedMessage.write(ctx, TagWriterImpl.newInstance(ctx, baos), t);
+      WrappedMessage.write(ctx, TagWriterImpl.newInstanceNoBuffer(ctx, baos), t);
       return baos.toByteArray();
    }
 
    public static ByteBuffer toWrappedByteBuffer(ImmutableSerializationContext ctx, Object t) throws IOException {
       ByteArrayOutputStreamEx baos = new ByteArrayOutputStreamEx(DEFAULT_ARRAY_BUFFER_SIZE);
-      WrappedMessage.write(ctx, TagWriterImpl.newInstance(ctx, baos), t);
+      WrappedMessage.write(ctx, TagWriterImpl.newInstanceNoBuffer(ctx, baos), t);
       return baos.getByteBuffer();
    }
 

--- a/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
+++ b/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
@@ -297,7 +297,7 @@ public final class WrappedMessage {
                ((EnumMarshallerDelegate) marshallerDelegate).encode(WRAPPED_ENUM, (Enum) t, out);
             } else {
                ByteArrayOutputStreamEx buffer = new ByteArrayOutputStreamEx();
-               TagWriterImpl nestedCtx = TagWriterImpl.newInstance(ctx, buffer);
+               TagWriterImpl nestedCtx = TagWriterImpl.newInstanceNoBuffer(ctx, buffer);
                marshallerDelegate.marshall(nestedCtx, null, t);
                nestedCtx.flush();
                out.writeBytes(WRAPPED_MESSAGE, buffer.getByteBuffer());
@@ -322,7 +322,7 @@ public final class WrappedMessage {
       out.writeUInt32(WRAPPED_CONTAINER_SIZE, containerSize);
 
       ByteArrayOutputStreamEx buffer = new ByteArrayOutputStreamEx();
-      TagWriterImpl nestedCtx = TagWriterImpl.newInstance(ctx, buffer);
+      TagWriterImpl nestedCtx = TagWriterImpl.newInstanceNoBuffer(ctx, buffer);
       marshallerDelegate.marshall(nestedCtx, null, container);
       nestedCtx.flush();
       out.writeBytes(WRAPPED_CONTAINER_MESSAGE, buffer.getByteBuffer());

--- a/core/src/main/java/org/infinispan/protostream/impl/JsonUtils.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/JsonUtils.java
@@ -75,7 +75,7 @@ public final class JsonUtils {
 
    public static byte[] fromCanonicalJSON(ImmutableSerializationContext ctx, Reader reader) throws IOException {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(ProtobufUtil.DEFAULT_ARRAY_BUFFER_SIZE);
-      TagWriter writer = TagWriterImpl.newInstance(ctx, baos);
+      TagWriter writer = TagWriterImpl.newInstanceNoBuffer(ctx, baos);
 
       JsonParser parser = jsonFactory.createParser(reader);
 
@@ -253,7 +253,7 @@ public final class JsonUtils {
             .collect(Collectors.toCollection(HashSet::new));
 
       ByteArrayOutputStream baos = new ByteArrayOutputStream(ProtobufUtil.DEFAULT_ARRAY_BUFFER_SIZE);
-      TagWriter nestedWriter = TagWriterImpl.newInstance(ctx, baos);
+      TagWriter nestedWriter = TagWriterImpl.newInstanceNoBuffer(ctx, baos);
 
       String currentField = null;
 

--- a/core/src/main/java/org/infinispan/protostream/impl/UnknownFieldSetImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/UnknownFieldSetImpl.java
@@ -199,7 +199,7 @@ public final class UnknownFieldSetImpl implements UnknownFieldSet, Externalizabl
    @Override
    public void writeExternal(ObjectOutput out) throws IOException {
       ByteArrayOutputStreamEx baos = new ByteArrayOutputStreamEx();
-      TagWriter output = TagWriterImpl.newInstance(null, baos);
+      TagWriter output = TagWriterImpl.newInstanceNoBuffer(null, baos);
       writeTo(output);
       output.flush();
       ByteBuffer buffer = baos.getByteBuffer();

--- a/core/src/test/java/org/infinispan/protostream/impl/TagWriterImplTest.java
+++ b/core/src/test/java/org/infinispan/protostream/impl/TagWriterImplTest.java
@@ -1,31 +1,160 @@
 package org.infinispan.protostream.impl;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
 
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.TagReader;
+import org.infinispan.protostream.TagWriter;
 import org.infinispan.protostream.descriptors.WireType;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author anistor@redhat.com
  */
 public class TagWriterImplTest {
 
+   private static final Log log = Log.LogFactory.getLog(TagWriterImplTest.class);
+   private static final long SEED = System.nanoTime();
+   private static final int MAX_BYTE_ARRAY_SIZE = 512;
+
    @Test
-   public void testWriteBool() throws Exception {
-      SerializationContext ctx = ProtobufUtil.newSerializationContext();
+   public void testByteArrayEncodeAndDecode() throws Exception {
+      byte[] buffer = new byte[MAX_BYTE_ARRAY_SIZE];
+      doTest(new Factory() {
+         @Override
+         public TagWriter newWriter(SerializationContext ctx) {
+            return TagWriterImpl.newInstance(ctx, buffer);
+         }
 
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      TagWriterImpl tagWriter = TagWriterImpl.newInstance(ctx, baos, 100);
-      tagWriter.writeBool(5, true);
-      tagWriter.flush();
-
-      byte[] bytes = baos.toByteArray();
-      assertEquals(2, bytes.length);
-      assertEquals(WireType.makeTag(5, WireType.VARINT), bytes[0]);
-      assertEquals(1, bytes[1]);
+         @Override
+         public TagReader newReader(SerializationContext ctx) {
+            return TagReaderImpl.newInstance(ctx, buffer);
+         }
+      });
    }
+
+   @Test
+   public void testOutputStreamEncodeAndDecode() throws Exception {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_BYTE_ARRAY_SIZE);
+      doTest(new Factory() {
+         @Override
+         public TagWriter newWriter(SerializationContext ctx) {
+            return TagWriterImpl.newInstance(ctx, baos);
+         }
+
+         @Override
+         public TagReader newReader(SerializationContext ctx) {
+            return TagReaderImpl.newInstance(ctx, new ByteArrayInputStream(baos.toByteArray()));
+         }
+      });
+   }
+
+   private void doTest(Factory factory) throws IOException {
+      log.infof("SEED is %s", SEED);
+      Random random = new Random(SEED);
+      Data data = new Data(random);
+      SerializationContext ctx = ProtobufUtil.newSerializationContext();
+      TagWriter writer = factory.newWriter(ctx);
+      int tag = 0;
+      // bool
+      writer.writeBool(++tag, data.b);
+      // ints
+      writer.writeInt32(++tag, data.i);
+      writer.writeSInt32(++tag, data.i);
+      writer.writeUInt32(++tag, Math.abs(data.i));
+      // longs
+      writer.writeInt64(++tag, data.l);
+      writer.writeSInt64(++tag, data.l);
+      writer.writeUInt64(++tag, Math.abs(data.l));
+      // double
+      writer.writeDouble(++tag, data.d);
+      // float
+      writer.writeFloat(++tag, data.f);
+      // string
+      writer.writeString(++tag, data.s);
+      // byte(s)
+      writer.writeBytes(++tag, data.bytes);
+      writer.writeBytes(++tag, data.bytes, 1, 2);
+      writer.flush();
+
+      TagReader reader = factory.newReader(ctx);
+      tag = 0;
+      // bool
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.b, reader.readBool());
+      // ints
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.i, reader.readInt32());
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.i, reader.readSInt32());
+      checkFieldNumber(++tag, reader);
+      assertEquals(Math.abs(data.i), reader.readUInt32());
+      // longs
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.l, reader.readInt64());
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.l, reader.readSInt64());
+      checkFieldNumber(++tag, reader);
+      assertEquals(Math.abs(data.l), reader.readUInt64());
+      // double
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.d, reader.readDouble(), 1);
+      // float
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.f, reader.readFloat(), 1);
+      // string
+      checkFieldNumber(++tag, reader);
+      assertEquals(data.s, reader.readString());
+      // byte(s)
+      checkFieldNumber(++tag, reader);
+      assertArrayEquals(data.bytes, reader.readByteArray());
+      checkFieldNumber(++tag, reader);
+      assertArrayEquals(new byte[]{data.bytes[1], data.bytes[2]}, reader.readByteArray());
+   }
+
+   private void checkFieldNumber(int expected, TagReader reader) throws IOException {
+      assertEquals(expected, WireType.getTagFieldNumber(reader.readTag()));
+   }
+
+   /**
+    * Creates a writer and stores the byte[] generated. Creates a reader from that byte[]
+    */
+   private interface Factory {
+      TagWriter newWriter(SerializationContext ctx);
+
+      TagReader newReader(SerializationContext ctx) throws IOException;
+   }
+
+   private static class Data {
+      final boolean b;
+      final int i;
+      final long l;
+      final double d;
+      final float f;
+      final String s;
+      final byte[] bytes;
+
+      private Data(Random random) {
+         b = random.nextBoolean();
+         i = random.nextInt();
+         l = random.nextLong();
+         d = random.nextDouble();
+         f = random.nextFloat();
+         s = random.ints('a', 'z')
+               .limit(10)
+               .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+               .toString();
+         bytes = new byte[15];
+         random.nextBytes(bytes);
+
+      }
+   }
+
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-228

JMH benchmark results (https://github.com/pruivo/benchmarks/blob/main/protostream-jmh/src/main/java/me/pruivo/ProtostreamBenchmark.java#L59)

4.4.1.Final
```
Benchmark                                 Mode  Cnt     Score    Error  Units
ProtostreamBenchmark.testMarshallAddress  avgt    6   979.152 ±  7.242  ns/op
ProtostreamBenchmark.testMarshallUser     avgt    6  3398.020 ± 34.846  ns/op
```

This PR
```
Benchmark                                 Mode  Cnt     Score   Error  Units
ProtostreamBenchmark.testMarshallAddress  avgt    6   265.675 ± 2.005  ns/op
ProtostreamBenchmark.testMarshallUser     avgt    6  1257.325 ± 7.937  ns/op
```