### PR TITLE
IPROTO-233 Fix MarshallerByteCodeGenerator on JDK 8 and 9+

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/MarshallerByteCodeGenerator.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/MarshallerByteCodeGenerator.java
@@ -9,6 +9,7 @@ import org.infinispan.protostream.BaseMarshaller;
 import org.infinispan.protostream.EnumMarshaller;
 import org.infinispan.protostream.ProtobufTagMarshaller;
 import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.annotations.impl.types.XClass;
 import org.infinispan.protostream.annotations.impl.types.XTypeFactory;
 import org.infinispan.protostream.containers.IndexedElementContainerAdapter;
 import org.infinispan.protostream.containers.IterableElementContainerAdapter;
@@ -144,10 +145,18 @@ final class MarshallerByteCodeGenerator extends AbstractMarshallerCodeGenerator 
       ctEncodeMethod.setBody(encodeSrc);
       marshallerImpl.addMethod(ctEncodeMethod);
 
-      Class<EnumMarshaller> generatedMarshallerClass = (Class<EnumMarshaller>) marshallerImpl.toClass(petm.getAnnotatedClass().asClass());
+      Class<EnumMarshaller> generatedMarshallerClass = (Class<EnumMarshaller>) toClass(marshallerImpl, petm.getAnnotatedClass());
       marshallerImpl.detach();
 
       return generatedMarshallerClass;
+   }
+
+   private Class<?> toClass(CtClass marshallerImpl, XClass petm) throws CannotCompileException {
+      if (System.getProperty("java.version").startsWith("1.8")) {
+         return marshallerImpl.toClass();
+      } else {
+         return marshallerImpl.toClass(petm.asClass());
+      }
    }
 
    /**
@@ -219,7 +228,7 @@ final class MarshallerByteCodeGenerator extends AbstractMarshallerCodeGenerator 
       ctWriteMethod.setBody(writeBody);
       marshallerImpl.addMethod(ctWriteMethod);
 
-      Class<ProtobufTagMarshaller> generatedMarshallerClass = (Class<ProtobufTagMarshaller>) marshallerImpl.toClass(pmtm.getAnnotatedClass().asClass());
+      Class<ProtobufTagMarshaller> generatedMarshallerClass = (Class<ProtobufTagMarshaller>) toClass(marshallerImpl, pmtm.getAnnotatedClass());
       marshallerImpl.detach();
 
       return generatedMarshallerClass;

--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AutoProtoSchemaBuilderAnnotationProcessor.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AutoProtoSchemaBuilderAnnotationProcessor.java
@@ -208,10 +208,11 @@ public final class AutoProtoSchemaBuilderAnnotationProcessor extends AbstractPro
    }
 
    private void ensureRequiredEnv() {
-      if (getJavaMajorVersion() < 9) {
+      if (getJavaMajorVersion() < 9 && !Boolean.getBoolean("org.infinispan.protostream.skipAnnotationCompilerCheck")) {
          reportWarning(null, "Please ensure you use at least Java ver. 9 for compilation in order to avoid various " +
                "compiler related bugs from older Java versions that impact the AutoProtoSchemaBuilder annotation " +
-               "processor (you can still set the output target to 8 or above).");
+               "processor (you can still set the output target to 8 or above). To hide this warning set the " +
+               "`org.infinispan.protostream.skipAnnotationCompilerCheck` system property");
       }
 
       Version procVersion = Version.getVersion(AutoProtoSchemaBuilder.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-233

Supersedes https://github.com/infinispan/protostream/pull/157

Use `mvn clean install -Dorg.infinispan.protostream.skipAnnotationCompilerCheck` to build on JDK 8.
