### PR TITLE
IPROTO-62 Implement annotation based schema generation support for 'oneof'

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/ProtoField.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/ProtoField.java
@@ -74,4 +74,6 @@ public @interface ProtoField {
     * that must be instantiated by the marshaling layer when reading this from a data stream.
     */
    Class<? extends Collection> collectionImplementation() default Collection.class;
+
+   String oneof() default "";
 }

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoFieldMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoFieldMetadata.java
@@ -20,6 +20,7 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
 
    private final int number;
    private final String name;
+   private final String oneof;
    private final XClass javaType;
    private final XClass collectionImplementation;
    private final Type protobufType;
@@ -36,12 +37,13 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
    private final XMethod getter;
    private final XMethod setter;  // setter is optional
 
-   ProtoFieldMetadata(int number, String name, XClass javaType,
+   ProtoFieldMetadata(int number, String name, String oneof, XClass javaType,
                       XClass collectionImplementation, Type protobufType, ProtoTypeMetadata protoTypeMetadata,
                       boolean isRequired, boolean isRepeated, boolean isArray, Object defaultValue,
                       XField field) {
       this.number = number;
       this.name = name;
+      this.oneof = oneof;
       this.javaType = javaType;
       this.collectionImplementation = collectionImplementation;
       this.protoTypeMetadata = protoTypeMetadata;
@@ -58,12 +60,13 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
       this.propertyName = field.getName();
    }
 
-   ProtoFieldMetadata(int number, String name, XClass javaType,
+   ProtoFieldMetadata(int number, String name, String oneof, XClass javaType,
                       XClass collectionImplementation, Type protobufType, ProtoTypeMetadata protoTypeMetadata,
                       boolean isRequired, boolean isRepeated, boolean isArray, Object defaultValue,
                       String propertyName, XMethod definingMethod, XMethod getter, XMethod setter) {
       this.number = number;
       this.name = name;
+      this.oneof = oneof;
       this.javaType = javaType;
       this.collectionImplementation = collectionImplementation;
       this.protoTypeMetadata = protoTypeMetadata;
@@ -90,6 +93,10 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
 
    public String getPropertyName() {
       return propertyName;
+   }
+
+   public String getOneof() {
+      return oneof;
    }
 
    /**
@@ -156,10 +163,12 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
    public void generateProto(IndentWriter iw) {
       iw.append('\n');
       ProtoTypeMetadata.appendDocumentation(iw, documentation);
-      if (isRepeated) {
-         iw.append("repeated ");
-      } else {
-         iw.append(isRequired ? "required " : "optional ");
+      if (oneof == null) {
+         if (isRepeated) {
+            iw.append("repeated ");
+         } else {
+            iw.append(isRequired ? "required " : "optional ");
+         }
       }
       String typeName;
       if (protobufType.getJavaType() == JavaType.ENUM || protobufType.getJavaType() == JavaType.MESSAGE) {
@@ -276,6 +285,7 @@ public final class ProtoFieldMetadata implements HasProtoSchema {
             ", protobufType=" + protobufType +
             ", javaType=" + javaType +
             ", collectionImplementation=" + collectionImplementation +
+            ", oneof=" + oneof +
             ", documentation='" + documentation + '\'' +
             ", protoTypeMetadata=" + (protoTypeMetadata != null ? protoTypeMetadata.getName() : null) +
             ", isRequired=" + isRequired +

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
@@ -8,6 +8,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,6 +17,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.infinispan.protostream.annotations.ProtoMessage;
@@ -186,8 +189,26 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
          t.generateProto(iw);
       }
 
-      for (ProtoFieldMetadata f : fieldsByNumber.values()) {
-         f.generateProto(iw);
+      LinkedList<ProtoFieldMetadata> unprocessedFields = new LinkedList<>(fieldsByNumber.values());
+      while (!unprocessedFields.isEmpty()) {
+         ProtoFieldMetadata f = unprocessedFields.remove();
+         if (f.getOneof() == null) {
+            f.generateProto(iw);
+         } else {
+            iw.append("\noneof ").append(f.getOneof()).append(" {\n");
+            iw.inc();
+            f.generateProto(iw);
+            Iterator<ProtoFieldMetadata> it = unprocessedFields.iterator();
+            while (it.hasNext()) {
+               ProtoFieldMetadata f2 = it.next();
+               if (f.getOneof().equals(f2.getOneof())) {
+                  f2.generateProto(iw);
+                  it.remove();
+               }
+            }
+            iw.dec();
+            iw.append("}\n");
+         }
       }
 
       iw.dec();
@@ -214,7 +235,10 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
          // all the fields discovered in this class hierarchy, by name
          fieldsByName = new HashMap<>();
 
-         discoverFields(annotatedClass, new HashSet<>());
+         // all the oneofs discovered in this class hierarchy
+         Set<String> oneofs = new HashSet<>();
+
+         discoverFields(annotatedClass, new HashSet<>(), fieldsByNumber, fieldsByName, oneofs);
          if (fieldsByNumber.isEmpty()) {
             //todo avoid this warning in case where not necessary
             // TODO [anistor] remove the "The class should be either annotated or it should have a custom marshaller" part after MessageMarshaller is removed in 5
@@ -341,17 +365,17 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
       }
    }
 
-   private void discoverFields(XClass clazz, Set<XClass> examinedClasses) {
+   private void discoverFields(XClass clazz, Set<XClass> examinedClasses, Map<Integer, ProtoFieldMetadata> fieldsByNumber, Map<String, ProtoFieldMetadata> fieldsByName, Set<String> oneofs) {
       if (!examinedClasses.add(clazz)) {
          // avoid re-examining classes due to multiple interface inheritance
          return;
       }
 
       if (clazz.getSuperclass() != null) {
-         discoverFields(clazz.getSuperclass(), examinedClasses);
+         discoverFields(clazz.getSuperclass(), examinedClasses, fieldsByNumber, fieldsByName, oneofs);
       }
       for (XClass i : clazz.getInterfaces()) {
-         discoverFields(i, examinedClasses);
+         discoverFields(i, examinedClasses, fieldsByNumber, fieldsByName, oneofs);
       }
 
       for (XField field : clazz.getDeclaredFields()) {
@@ -361,6 +385,9 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
             }
             if (unknownFieldSetField != null || unknownFieldSetGetter != null || unknownFieldSetSetter != null) {
                throw new ProtoSchemaBuilderException("The @ProtoUnknownFieldSet annotation should not occur more than once in a class and its superclasses and superinterfaces : " + clazz.getCanonicalName() + '.' + field);
+            }
+            if (field.getAnnotation(ProtoField.class) != null) {
+               throw new ProtoSchemaBuilderException("The @ProtoUnknownFieldSet and @ProtoField annotations cannot be used together: " + field);
             }
             unknownFieldSetField = field;
          } else {
@@ -424,7 +451,21 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                if (protobufType.getJavaType() == JavaType.ENUM || protobufType.getJavaType() == JavaType.MESSAGE) {
                   protoTypeMetadata = protoSchemaGenerator.scanAnnotations(javaType);
                }
-               ProtoFieldMetadata fieldMetadata = new ProtoFieldMetadata(number, fieldName, javaType, collectionImplementation,
+
+               String oneof = annotation.oneof();
+               if (oneof.isEmpty()) {
+                  oneof = null;
+               } else {
+                  if (oneof.equals(fieldName) || fieldsByName.containsKey(oneof)) {
+                     throw new ProtoSchemaBuilderException("The field named '" + fieldName + "' of " + clazz.getName() + " is member of the '" + oneof + "' oneof which collides with an existing field or oneof.");
+                  }
+                  if (isRepeated || isRequired) {
+                     throw new ProtoSchemaBuilderException("The field named '" + fieldName + "' of " + clazz.getName() + " cannot be marked repeated or required since it is member of the '" + oneof + " oneof.");
+                  }
+                  oneofs.add(oneof);
+               }
+
+               ProtoFieldMetadata fieldMetadata = new ProtoFieldMetadata(number, fieldName, oneof, javaType, collectionImplementation,
                      protobufType, protoTypeMetadata, isRequired, isRepeated, isArray, defaultValue, field);
 
                ProtoFieldMetadata existing = fieldsByNumber.get(number);
@@ -445,10 +486,19 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
          }
       }
 
+      Set<XMethod> skipMethods = new HashSet<>();
+
       for (XMethod method : clazz.getDeclaredMethods()) {
+         if (skipMethods.contains(method)) {
+            continue;
+         }
+
          if (method.getAnnotation(ProtoUnknownFieldSet.class) != null) {
             if (unknownFieldSetField != null || unknownFieldSetGetter != null || unknownFieldSetSetter != null) {
                throw new ProtoSchemaBuilderException("The @ProtoUnknownFieldSet annotation should not occur more than once in a class and its superclasses and superinterfaces : " + method);
+            }
+            if (method.getAnnotation(ProtoField.class) != null) {
+               throw new ProtoSchemaBuilderException("The @ProtoUnknownFieldSet and @ProtoField annotations cannot be used together: " + method);
             }
             String propertyName;
             if (method.getReturnType() == typeFactory.fromClass(void.class)) {
@@ -464,6 +514,8 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                //TODO [anistor] also check setter args
                unknownFieldSetSetter = method;
                unknownFieldSetGetter = findGetter(propertyName, method.getParameterTypes()[0]);
+               checkForbiddenAnnotations(unknownFieldSetGetter, unknownFieldSetSetter);
+               skipMethods.add(unknownFieldSetGetter);
             } else {
                // this method is expected to be a getter
                if (method.getName().startsWith("get") && method.getName().length() > 3) {
@@ -479,6 +531,8 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                //TODO [anistor] also check getter args
                unknownFieldSetGetter = method;
                unknownFieldSetSetter = findSetter(propertyName, unknownFieldSetGetter.getReturnType());
+               checkForbiddenAnnotations(unknownFieldSetSetter, unknownFieldSetGetter);
+               skipMethods.add(unknownFieldSetSetter);
             }
          } else {
             ProtoField annotation = method.getAnnotation(ProtoField.class);
@@ -508,6 +562,8 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                   //TODO [anistor] also check setter args
                   setter = method;
                   getter = findGetter(propertyName, method.getParameterTypes()[0]);
+                  checkForbiddenAnnotations(getter, setter);
+                  skipMethods.add(getter);
                   getterReturnType = getter.getReturnType();
                   if (getterReturnType == typeFactory.fromClass(Optional.class)) {
                      getterReturnType = getter.determineOptionalReturnType();
@@ -531,7 +587,13 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                   if (getterReturnType == typeFactory.fromClass(Optional.class)) {
                      getterReturnType = getter.determineOptionalReturnType();
                   }
-                  setter = factory == null ? findSetter(propertyName, getterReturnType) : null;
+                  if (factory == null) {
+                     setter = findSetter(propertyName, getterReturnType);
+                     checkForbiddenAnnotations(setter, getter);
+                     skipMethods.add(setter);
+                  } else {
+                     setter = null;
+                  }
                }
 
                int number = getNumber(annotation, method);
@@ -582,7 +644,19 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                   protoTypeMetadata = protoSchemaGenerator.scanAnnotations(javaType);
                }
 
-               ProtoFieldMetadata fieldMetadata = new ProtoFieldMetadata(number, fieldName, javaType, collectionImplementation,
+               String oneof = annotation.oneof();
+               if (oneof.isEmpty()) {
+                  oneof = null;
+               } else {
+                  if (oneof.equals(fieldName) || fieldsByName.containsKey(oneof)) {
+                     throw new ProtoSchemaBuilderException("The field named '" + fieldName + "' of " + clazz.getName() + " is member of the '" + oneof + "' oneof which collides with an existing field or oneof.");
+                  }
+                  if (isRepeated || isRequired) {
+                     throw new ProtoSchemaBuilderException("The field named '" + fieldName + "' of " + clazz.getName() + " cannot be marked repeated or required since it is member of the '" + oneof + " oneof.");
+                  }
+                  oneofs.add(oneof);
+               }
+               ProtoFieldMetadata fieldMetadata = new ProtoFieldMetadata(number, fieldName, oneof, javaType, collectionImplementation,
                      protobufType, protoTypeMetadata, isRequired, isRepeated, isArray, defaultValue,
                      propertyName, method, getter, setter);
 
@@ -1059,6 +1133,14 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
                   + ". The candidate method does not have a suitable return type: " + setter);
          }
          return setter;
+      }
+   }
+
+   private void checkForbiddenAnnotations(XMethod m1, XMethod m2) {
+      if (m1.getAnnotation(ProtoDoc.class) != null
+            || m1.getAnnotation(ProtoField.class) != null
+            || m1.getAnnotation(ProtoUnknownFieldSet.class) != null) {
+         throw new ProtoSchemaBuilderException("No @ProtoDoc, @ProtoField or @ProtoUnknownFieldSet annotations allowed on method " + m1 + ". They should have been added to " + m2);
       }
    }
 

--- a/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
+++ b/core/src/test/java/org/infinispan/protostream/annotations/impl/ProtoSchemaBuilderTest.java
@@ -2048,4 +2048,77 @@ public class ProtoSchemaBuilderTest extends AbstractProtoStreamTest {
       assertFalse(schema.contains("message InnerMessage3"));  // InnerMessage3 is a nested class but still not included
       assertFalse(schema.contains("baseField1"));
    }
+
+   @ProtoDoc("A test for 'oneof'")
+   public static class TestOneof {
+
+      @ProtoField(number = 1, oneof = "oneof1")
+      public String fieldA;
+
+      @ProtoField(number = 2, oneof = "oneof1")
+      public String fieldB;
+
+      @ProtoField(number = 3)
+      public String fieldC;
+
+      @ProtoField(number = 4, oneof = "oneof2")
+      public String fieldD;
+
+      @ProtoField(number = 5, oneof = "oneof2")
+      public String fieldE;
+   }
+
+   @Test
+   public void testOneOf() throws Exception {
+      SerializationContext ctx = createContext();
+      ProtoSchemaBuilder protoSchemaBuilder = new ProtoSchemaBuilder();
+      protoSchemaBuilder
+            .fileName("test.proto")
+            .addClass(TestOneof.class)
+            .build(ctx);
+
+      assertTrue(ctx.canMarshall(TestOneof.class));
+      assertTrue(ctx.canMarshall("TestOneof"));
+   }
+
+   public static class TestInvalidOneof1 {
+
+      @ProtoField(number = 1, oneof = "fieldA")
+      public String fieldA;
+   }
+
+   @Test
+   public void testInvalidOneOf1() throws Exception {
+      exception.expect(ProtoSchemaBuilderException.class);
+      exception.expectMessage("The field named 'fieldA' of org.infinispan.protostream.annotations.impl.ProtoSchemaBuilderTest$TestInvalidOneof1 is member of the 'fieldA' oneof which collides with an existing field or oneof.");
+
+      SerializationContext ctx = createContext();
+      ProtoSchemaBuilder protoSchemaBuilder = new ProtoSchemaBuilder();
+      protoSchemaBuilder
+            .fileName("test.proto")
+            .addClass(TestInvalidOneof1.class)
+            .build(ctx);
+   }
+
+   public static class TestInvalidOneof2 {
+
+      @ProtoField(number = 1, name = "fieldX")
+      public String fieldA;
+
+      @ProtoField(number = 2, name = "fieldX")
+      public String fieldB;
+   }
+
+   @Test
+   public void testDuplicateFieldName() throws Exception {
+      exception.expect(ProtoSchemaBuilderException.class);
+      exception.expectMessage("Duplicate field name definition. Found two field definitions with name 'fieldX': in public java.lang.String org.infinispan.protostream.annotations.impl.ProtoSchemaBuilderTest$TestInvalidOneof2.fieldB and in public java.lang.String org.infinispan.protostream.annotations.impl.ProtoSchemaBuilderTest$TestInvalidOneof2.fieldA");
+
+      SerializationContext ctx = createContext();
+      ProtoSchemaBuilder protoSchemaBuilder = new ProtoSchemaBuilder();
+      protoSchemaBuilder
+            .fileName("test.proto")
+            .addClass(TestInvalidOneof2.class)
+            .build(ctx);
+   }
 }

--- a/core/src/test/java/org/infinispan/protostream/annotations/impl/testdomain/Simple.java
+++ b/core/src/test/java/org/infinispan/protostream/annotations/impl/testdomain/Simple.java
@@ -17,6 +17,7 @@ public class Simple {
    @ProtoField(number = 1111)
    public Simple simple;
 
+   //todo [anistor] should be possible not to require 'required' in this case because it is implied already?
    @ProtoField(number = 1, required = true, defaultValue = "0.0")
    public float afloat;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-62

I think that we can evaluate the idea of merge this Adrian's contribution to support the generation of `oneof` clause from `@ProtoField` annotations