### PR TITLE
IPROTO-248 Make parent/pom.xml valid against Maven XSD

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -349,7 +349,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration combine.self="append">
+                    <configuration>
                         <release>11</release>
                         <encoding>UTF-8</encoding>
                         <!-- both maven and javac are buggy regarding handling of APs with incremental compilation -->


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-248

Details in JIRA description.