### PR TITLE
IPROTO-265 Remove additional byte[] allocations for nested writers

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/Decoder.java
+++ b/core/src/main/java/org/infinispan/protostream/Decoder.java
@@ -1,0 +1,55 @@
+package org.infinispan.protostream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public interface Decoder {
+   int getEnd();
+
+   int getPos();
+
+   byte[] getBufferArray() throws IOException;
+
+   boolean isAtEnd() throws IOException;
+
+   int readTag() throws IOException;
+
+   void checkLastTagWas(int expectedTag) throws IOException;
+
+   boolean skipField(int tag) throws IOException;
+
+   void skipVarint() throws IOException;
+
+   void skipRawBytes(int length) throws IOException;
+
+   String readString() throws IOException;
+
+   byte readRawByte() throws IOException;
+
+   byte[] readRawByteArray(int length) throws IOException;
+
+   ByteBuffer readRawByteBuffer(int length) throws IOException;
+
+   int readVarint32() throws IOException;
+
+   long readVarint64() throws IOException;
+
+   int readFixed32() throws IOException;
+
+   long readFixed64() throws IOException;
+
+   int pushLimit(int newLimit) throws IOException;
+
+   void popLimit(int oldLimit);
+
+   Decoder decoderFromLength(int length) throws IOException;
+
+   /**
+    * Sets a hard limit on how many bytes we can continue to read while parsing a message from current position. This is
+    * useful to prevent corrupted or malicious messages with wrong length values to abuse memory allocation. Initially
+    * this limit is set to {@code Integer.MAX_INT}, which means the protection mechanism is disabled by default.
+    * The limit is only useful when processing streams. Setting a limit for a decoder backed by a byte array is useless
+    * because the memory allocation already happened.
+    */
+   int setGlobalLimit(int globalLimit);
+}

--- a/core/src/main/java/org/infinispan/protostream/Encoder.java
+++ b/core/src/main/java/org/infinispan/protostream/Encoder.java
@@ -1,0 +1,50 @@
+package org.infinispan.protostream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public interface Encoder {
+   void flush() throws IOException;
+
+   void close() throws IOException;
+
+   int remainingSpace();
+
+   void writeUInt32Field(int fieldNumber, int value) throws IOException;
+
+   void writeUInt64Field(int fieldNumber, long value) throws IOException;
+
+   void writeFixed32Field(int fieldNumber, int value) throws IOException;
+
+   void writeFixed64Field(int fieldNumber, long value) throws IOException;
+
+   void writeBoolField(int fieldNumber, boolean value) throws IOException;
+
+   void writeLengthDelimitedField(int fieldNumber, int length) throws IOException;
+
+   void writeVarint32(int value) throws IOException;
+
+   void writeVarint64(long value) throws IOException;
+
+   void writeFixed32(int value) throws IOException;
+
+   void writeFixed64(long value) throws IOException;
+
+   void writeByte(byte value) throws IOException;
+
+   void writeBytes(byte[] value, int offset, int length) throws IOException;
+
+   void writeBytes(ByteBuffer value) throws IOException;
+
+   default int skipFixedVarint() {
+      throw new UnsupportedOperationException();
+   }
+
+   default void writePositiveFixedVarint(int pos) {
+      throw new UnsupportedOperationException();
+   }
+
+   default boolean supportsFixedVarint() {
+      return false;
+   }
+}

--- a/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
+++ b/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
@@ -143,7 +143,7 @@ public final class ProtobufUtil {
    }
 
    public static byte[] toWrappedByteArray(ImmutableSerializationContext ctx, Object t, int bufferSize) throws IOException {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream(bufferSize);
+      ByteArrayOutputStream baos = new ByteArrayOutputStreamEx(bufferSize);
       WrappedMessage.write(ctx, TagWriterImpl.newInstanceNoBuffer(ctx, baos), t);
       return baos.toByteArray();
    }
@@ -155,7 +155,7 @@ public final class ProtobufUtil {
    }
 
    public static void toWrappedStream(ImmutableSerializationContext ctx, OutputStream out, Object t) throws IOException {
-      toWrappedStream(ctx, out, t, DEFAULT_STREAM_BUFFER_SIZE);
+      WrappedMessage.write(ctx, TagWriterImpl.newInstance(ctx, out), t);
    }
 
    public static void toWrappedStream(ImmutableSerializationContext ctx, OutputStream out, Object t, int bufferSize) throws IOException {

--- a/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
+++ b/core/src/main/java/org/infinispan/protostream/ProtobufUtil.java
@@ -75,6 +75,10 @@ public final class ProtobufUtil {
       write(ctx, TagWriterImpl.newInstance(ctx, out), t);
    }
 
+   public static void writeTo(ImmutableSerializationContext ctx, Encoder encoder, Object t) throws IOException {
+      write(ctx, TagWriterImpl.newInstance(ctx, encoder), t);
+   }
+
    public static byte[] toByteArray(ImmutableSerializationContext ctx, Object t) throws IOException {
       ByteArrayOutputStream baos = new ByteArrayOutputStream(DEFAULT_ARRAY_BUFFER_SIZE);
       writeTo(ctx, baos, t);
@@ -112,6 +116,10 @@ public final class ProtobufUtil {
       return readFrom(TagReaderImpl.newInstance(ctx, byteBuffer), clazz);
    }
 
+   public static <A> A fromDecoder(ImmutableSerializationContext ctx, Decoder decoder, Class<A> clazz) throws IOException {
+      return readFrom(TagReaderImpl.newInstance(ctx, decoder), clazz);
+   }
+
    /**
     * Parses a top-level message that was wrapped according to the org.infinispan.protostream.WrappedMessage proto
     * definition.
@@ -137,6 +145,10 @@ public final class ProtobufUtil {
       return WrappedMessage.read(ctx, TagReaderImpl.newInstance(ctx, in));
    }
 
+   public static <A> A fromWrappedDecoder(ImmutableSerializationContext ctx, Decoder decoder) throws IOException {
+      return WrappedMessage.read(ctx, TagReaderImpl.newInstance(ctx, decoder));
+   }
+
    //todo [anistor] should make it possible to plug in a custom wrapping strategy instead of the default one
    public static byte[] toWrappedByteArray(ImmutableSerializationContext ctx, Object t) throws IOException {
       return toWrappedByteArray(ctx, t, DEFAULT_ARRAY_BUFFER_SIZE);
@@ -160,6 +172,10 @@ public final class ProtobufUtil {
 
    public static void toWrappedStream(ImmutableSerializationContext ctx, OutputStream out, Object t, int bufferSize) throws IOException {
       WrappedMessage.write(ctx, TagWriterImpl.newInstance(ctx, out, bufferSize), t);
+   }
+
+   public static void toWrappedEncoder(ImmutableSerializationContext ctx, Encoder encoder, Object t) throws IOException {
+      WrappedMessage.write(ctx, TagWriterImpl.newInstance(ctx, encoder), t);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/protostream/TagReader.java
+++ b/core/src/main/java/org/infinispan/protostream/TagReader.java
@@ -33,7 +33,9 @@ public interface TagReader extends RawProtoStreamReader {
 
    boolean readBool() throws IOException;
 
-   int readEnum() throws IOException;
+   default int readEnum() throws IOException {
+      return readInt32();
+   }
 
    /**
     * Reads a {@code string} value.
@@ -50,29 +52,48 @@ public interface TagReader extends RawProtoStreamReader {
     */
    ByteBuffer readByteBuffer() throws IOException;
 
-   double readDouble() throws IOException;
+   /**
+    * Similar to {@link #readByteArray()} except that the reader impl may optimize creation of a sub TagReader from
+    * itself, possibly avoiding byte[] allocations
+    * @return a new TagReader
+    */
+   TagReader subReaderFromArray() throws IOException;
 
-   float readFloat() throws IOException;
+   default double readDouble() throws IOException {
+      return Double.longBitsToDouble(readFixed64());
+   }
+
+   default float readFloat() throws IOException {
+      return Float.intBitsToFloat(readFixed32());
+   }
 
    long readInt64() throws IOException;
 
-   long readUInt64() throws IOException;
+   default long readUInt64() throws IOException {
+      return readInt64();
+   }
 
    long readSInt64() throws IOException;
 
    long readFixed64() throws IOException;
 
-   long readSFixed64() throws IOException;
+   default long readSFixed64() throws IOException {
+      return readFixed64();
+   }
 
    int readInt32() throws IOException;
 
-   int readUInt32() throws IOException;
+   default int readUInt32() throws IOException {
+      return readInt32();
+   }
 
    int readSInt32() throws IOException;
 
    int readFixed32() throws IOException;
 
-   int readSFixed32() throws IOException;
+   default int readSFixed32() throws IOException {
+      return readFixed32();
+   }
 
    /**
     * Sets a limit (based on the length of the length delimited value) when entering an embedded message.

--- a/core/src/main/java/org/infinispan/protostream/TagReader.java
+++ b/core/src/main/java/org/infinispan/protostream/TagReader.java
@@ -57,7 +57,7 @@ public interface TagReader extends RawProtoStreamReader {
     * itself, possibly avoiding byte[] allocations
     * @return a new TagReader
     */
-   TagReader subReaderFromArray() throws IOException;
+   ProtobufTagMarshaller.ReadContext subReaderFromArray() throws IOException;
 
    default double readDouble() throws IOException {
       return Double.longBitsToDouble(readFixed64());

--- a/core/src/main/java/org/infinispan/protostream/TagWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/TagWriter.java
@@ -1,5 +1,6 @@
 package org.infinispan.protostream;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -9,14 +10,14 @@ import org.infinispan.protostream.descriptors.WireType;
  * @author anistor@redhat.com
  * @since 4.4
  */
-public interface TagWriter extends RawProtoStreamWriter {
+public interface TagWriter extends RawProtoStreamWriter, Closeable {
 
    // start low level ops
    void flush() throws IOException;
 
    /**
     * Invoke after done with writer, this implies a flush if necessary
-    * It is necessary to invoke this on a writer returned from {@link #subWriter(int)} to actually push the data
+    * It is necessary to invoke this on a writer returned from {@link #subWriter(int, boolean)} to actually push the data
     */
    void close() throws IOException;
 
@@ -99,9 +100,12 @@ public interface TagWriter extends RawProtoStreamWriter {
 
    /**
     * Used to write a sub message that can be optimized by implementation. When the sub writer is complete, flush
-    * should be invoked to ensure
-    * @return
-    * @throws IOException
+    * should be invoked to ensure bytes are written and close should be invoked to free any resources related to the
+    * context (note close will flush as well)
+    * @param number the message number of the sub message
+    * @param nested whether this is a nested message or a new one
+    * @return a write context for a sub message
+    * @throws IOException exception if there is an issue
     */
-   TagWriter subWriter(int number, boolean nested) throws IOException;
+   ProtobufTagMarshaller.WriteContext subWriter(int number, boolean nested) throws IOException;
 }

--- a/core/src/main/java/org/infinispan/protostream/TagWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/TagWriter.java
@@ -14,9 +14,19 @@ public interface TagWriter extends RawProtoStreamWriter {
    // start low level ops
    void flush() throws IOException;
 
-   void writeTag(int number, int wireType) throws IOException;
+   /**
+    * Invoke after done with writer, this implies a flush if necessary
+    * It is necessary to invoke this on a writer returned from {@link #subWriter(int)} to actually push the data
+    */
+   void close() throws IOException;
 
-   void writeTag(int number, WireType wireType) throws IOException;
+   default void writeTag(int number, int wireType) throws IOException {
+      writeVarint32(WireType.makeTag(number, wireType));
+   }
+
+   default void writeTag(int number, WireType wireType) throws IOException {
+      writeVarint32(WireType.makeTag(number, wireType));
+   }
 
    void writeVarint32(int value) throws IOException;
 
@@ -28,38 +38,70 @@ public interface TagWriter extends RawProtoStreamWriter {
    // start high level ops
    void writeString(int number, String value) throws IOException;
 
-   void writeInt32(int number, int value) throws IOException;
+   default void writeInt32(int number, int value) throws IOException {
+      if (value >= 0) {
+         writeUInt32(number, value);
+      } else {
+         writeUInt64(number, value);
+      }
+   }
 
    void writeUInt32(int number, int value) throws IOException;
 
-   void writeSInt32(int number, int value) throws IOException;
+   default void writeSInt32(int number, int value) throws IOException {
+      // Roll the bits in order to move the sign bit from position 31 to position 0, to reduce the wire length of negative numbers.
+      writeUInt32(number, (value << 1) ^ (value >> 31));
+   }
 
    void writeFixed32(int number, int value) throws IOException;
 
-   void writeSFixed32(int number, int value) throws IOException;
+   default void writeSFixed32(int number, int value) throws IOException {
+      writeFixed32(number, value);
+   }
 
    void writeInt64(int number, long value) throws IOException;
 
    void writeUInt64(int number, long value) throws IOException;
 
-   void writeSInt64(int number, long value) throws IOException;
+   default void writeSInt64(int number, long value) throws IOException {
+      // Roll the bits in order to move the sign bit from position 63 to position 0, to reduce the wire length of negative numbers.
+      writeUInt64(number, (value << 1) ^ (value >> 63));
+   }
 
    void writeFixed64(int number, long value) throws IOException;
 
-   void writeSFixed64(int number, long value) throws IOException;
+   default void writeSFixed64(int number, long value) throws IOException {
+      writeFixed64(number, value);
+   }
 
-   void writeEnum(int number, int value) throws IOException;
+   default void writeEnum(int number, int value) throws IOException {
+      writeInt32(number, value);
+   }
 
    void writeBool(int number, boolean value) throws IOException;
 
-   void writeDouble(int number, double value) throws IOException;
+   default void writeDouble(int number, double value) throws IOException {
+      writeFixed64(number, Double.doubleToRawLongBits(value));
+   }
 
-   void writeFloat(int number, float value) throws IOException;
+   default void writeFloat(int number, float value) throws IOException {
+      writeFixed32(number, Float.floatToRawIntBits(value));
+   }
 
    void writeBytes(int number, ByteBuffer value) throws IOException;
 
-   void writeBytes(int number, byte[] value) throws IOException;
+   default void writeBytes(int number, byte[] value) throws IOException {
+      writeBytes(number, value, 0, value.length);
+   }
 
    void writeBytes(int number, byte[] value, int offset, int length) throws IOException;
    // end high level ops
+
+   /**
+    * Used to write a sub message that can be optimized by implementation. When the sub writer is complete, flush
+    * should be invoked to ensure
+    * @return
+    * @throws IOException
+    */
+   TagWriter subWriter(int number, boolean nested) throws IOException;
 }

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
@@ -3,6 +3,7 @@ package org.infinispan.protostream.annotations.impl;
 import java.io.IOException;
 
 import org.infinispan.protostream.ProtobufTagMarshaller;
+import org.infinispan.protostream.TagWriter;
 import org.infinispan.protostream.impl.BaseMarshallerDelegate;
 import org.infinispan.protostream.impl.ByteArrayOutputStreamEx;
 import org.infinispan.protostream.impl.Log;
@@ -46,6 +47,17 @@ public class GeneratedMarshallerBase {
          throw log.maxNestedMessageDepth(maxNestedMessageDepth, message.getClass());
       }
 
+      if (ctx instanceof TagWriter) {
+         TagWriter nestedWriter = ((TagWriter) ctx).subWriter(fieldNumber, true);
+         marshallerDelegate.marshall((ProtobufTagMarshaller.WriteContext) nestedWriter, null, message);
+         nestedWriter.close();
+      } else {
+         handleNonTagWriter(marshallerDelegate, ctx, fieldNumber, message);
+      }
+   }
+
+   private <T> void handleNonTagWriter(BaseMarshallerDelegate<T> marshallerDelegate, ProtobufTagMarshaller.WriteContext ctx,
+                                   int fieldNumber, T message) throws IOException {
       ByteArrayOutputStreamEx baos = new ByteArrayOutputStreamEx();
       TagWriterImpl nested = TagWriterImpl.newNestedInstance(ctx, baos);
       writeMessage(marshallerDelegate, nested, message);

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
@@ -1,13 +1,12 @@
 package org.infinispan.protostream.annotations.impl;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 import org.infinispan.protostream.ProtobufTagMarshaller;
 import org.infinispan.protostream.TagWriter;
 import org.infinispan.protostream.impl.BaseMarshallerDelegate;
-import org.infinispan.protostream.impl.ByteArrayOutputStreamEx;
 import org.infinispan.protostream.impl.Log;
-import org.infinispan.protostream.impl.TagWriterImpl;
 
 /**
  * Base class for generated message marshallers. Provides some handy helper methods.
@@ -47,20 +46,11 @@ public class GeneratedMarshallerBase {
          throw log.maxNestedMessageDepth(maxNestedMessageDepth, message.getClass());
       }
 
-      if (ctx instanceof TagWriter) {
-         TagWriter nestedWriter = ((TagWriter) ctx).subWriter(fieldNumber, true);
-         marshallerDelegate.marshall((ProtobufTagMarshaller.WriteContext) nestedWriter, null, message);
-         nestedWriter.close();
-      } else {
-         handleNonTagWriter(marshallerDelegate, ctx, fieldNumber, message);
+      TagWriter tagWriter = ctx.getWriter();
+      ProtobufTagMarshaller.WriteContext nestedWriter = tagWriter.subWriter(fieldNumber, true);
+      marshallerDelegate.marshall(nestedWriter, null, message);
+      if (nestedWriter instanceof Closeable) {
+         ((Closeable) nestedWriter).close();
       }
-   }
-
-   private <T> void handleNonTagWriter(BaseMarshallerDelegate<T> marshallerDelegate, ProtobufTagMarshaller.WriteContext ctx,
-                                   int fieldNumber, T message) throws IOException {
-      ByteArrayOutputStreamEx baos = new ByteArrayOutputStreamEx();
-      TagWriterImpl nested = TagWriterImpl.newNestedInstance(ctx, baos);
-      writeMessage(marshallerDelegate, nested, message);
-      ctx.getWriter().writeBytes(fieldNumber, baos.getByteBuffer());
    }
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/ByteArrayOutputStreamEx.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/ByteArrayOutputStreamEx.java
@@ -21,4 +21,14 @@ public final class ByteArrayOutputStreamEx extends ByteArrayOutputStream {
    public synchronized ByteBuffer getByteBuffer() {
       return ByteBuffer.wrap(buf, 0, count);
    }
+
+   public int skipFixedVarint() {
+      int prev = count;
+      count += 5;
+      return prev;
+   }
+
+   public void writePositiveFixedVarint(int pos) {
+      TagWriterImpl.writePositiveFixedVarint(buf, pos, count - pos - 5);
+   }
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/TagWriterImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/TagWriterImpl.java
@@ -10,14 +10,15 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.infinispan.protostream.ImmutableSerializationContext;
 import org.infinispan.protostream.ProtobufTagMarshaller;
-import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.TagWriter;
 import org.infinispan.protostream.descriptors.WireType;
+
 
 /**
  * @author anistor@redhat.com
@@ -66,9 +67,13 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    }
 
    public static TagWriterImpl newInstance(ImmutableSerializationContext serCtx, OutputStream output) {
-      return new TagWriterImpl((SerializationContextImpl) serCtx, new OutputStreamEncoder(output, ProtobufUtil.DEFAULT_STREAM_BUFFER_SIZE));
+      return new TagWriterImpl((SerializationContextImpl) serCtx, new OutputStreamNoBufferEncoder(output));
    }
 
+   /**
+    * @deprecated since 4.6.3 Please use {@link #newInstance(ImmutableSerializationContext, OutputStream)} with a {@link java.io.BufferedOutputStream instead}
+    */
+   @Deprecated
    public static TagWriterImpl newInstance(ImmutableSerializationContext serCtx, OutputStream output, int bufferSize) {
       return new TagWriterImpl((SerializationContextImpl) serCtx, new OutputStreamEncoder(output, bufferSize));
    }
@@ -105,13 +110,8 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    }
 
    @Override
-   public void writeTag(int number, int wireType) throws IOException {
-      encoder.writeVarint32(WireType.makeTag(number, wireType));
-   }
-
-   @Override
-   public void writeTag(int number, WireType wireType) throws IOException {
-      encoder.writeVarint32(WireType.makeTag(number, wireType));
+   public void close() throws IOException {
+      encoder.close();
    }
 
    @Override
@@ -137,33 +137,13 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    }
 
    @Override
-   public void writeInt32(int number, int value) throws IOException {
-      if (value >= 0) {
-         encoder.writeUInt32Field(number, value);
-      } else {
-         encoder.writeUInt64Field(number, value);
-      }
-   }
-
-   @Override
    public void writeUInt32(int number, int value) throws IOException {
       encoder.writeUInt32Field(number, value);
    }
 
    @Override
-   public void writeSInt32(int number, int value) throws IOException {
-      // Roll the bits in order to move the sign bit from position 31 to position 0, to reduce the wire length of negative numbers.
-      encoder.writeUInt32Field(number, (value << 1) ^ (value >> 31));
-   }
-
-   @Override
    public void writeFixed32(int number, int value) throws IOException {
       encoder.writeFixed32Field(number, value);
-   }
-
-   @Override
-   public void writeSFixed32(int number, int value) throws IOException {
-      writeFixed32(number, value);
    }
 
    @Override
@@ -177,39 +157,13 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    }
 
    @Override
-   public void writeSInt64(int number, long value) throws IOException {
-      // Roll the bits in order to move the sign bit from position 63 to position 0, to reduce the wire length of negative numbers.
-      encoder.writeUInt64Field(number, (value << 1) ^ (value >> 63));
-   }
-
-   @Override
    public void writeFixed64(int number, long value) throws IOException {
       encoder.writeFixed64Field(number, value);
    }
 
    @Override
-   public void writeSFixed64(int number, long value) throws IOException {
-      writeFixed64(number, value);
-   }
-
-   @Override
-   public void writeEnum(int number, int value) throws IOException {
-      writeInt32(number, value);
-   }
-
-   @Override
    public void writeBool(int number, boolean value) throws IOException {
       encoder.writeBoolField(number, value);
-   }
-
-   @Override
-   public void writeDouble(int number, double value) throws IOException {
-      encoder.writeFixed64Field(number, Double.doubleToRawLongBits(value));
-   }
-
-   @Override
-   public void writeFloat(int number, float value) throws IOException {
-      encoder.writeFixed32Field(number, Float.floatToRawIntBits(value));
    }
 
    @Override
@@ -219,14 +173,35 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    }
 
    @Override
-   public void writeBytes(int number, byte[] value) throws IOException {
-      writeBytes(number, value, 0, value.length);
-   }
-
-   @Override
    public void writeBytes(int number, byte[] value, int offset, int length) throws IOException {
       encoder.writeLengthDelimitedField(number, length);
       encoder.writeBytes(value, offset, length);
+   }
+
+   @Override
+   public TagWriter subWriter(int number, boolean nested) throws IOException {
+      if (encoder.supportsFixedVarint()) {
+         writeVarint32(WireType.makeTag(number, WireType.WIRETYPE_LENGTH_DELIMITED));
+         return nested ? new TagWriterImpl(this, new FixedVarintWrappedEncoder((FixedVarintEncoder) encoder)) :
+               new TagWriterImpl(serCtx, new FixedVarintWrappedEncoder((FixedVarintEncoder) encoder));
+      }
+      // This ensures we aren't allocating a byte[] larger than we actually need
+      int space = bytesAvailableForVariableEncoding(encoder.remainingSpace());
+      return nested ? new TagWriterImpl(this, new ArrayBasedWrappedEncoder(space, encoder, number)) :
+            new TagWriterImpl(serCtx, new ArrayBasedWrappedEncoder(space, encoder, number));
+   }
+
+   // Returns how many bytes are usable for data from a given range of bytes when inserting a variable int before
+   // the actual data
+   private int bytesAvailableForVariableEncoding(int spaceAllowed) {
+      if (spaceAllowed < 128) {
+         return spaceAllowed - 1;
+      } else if (spaceAllowed < 16384) {
+         return spaceAllowed - 2;
+      } else if (spaceAllowed < 2097151) {
+         return spaceAllowed - 3;
+      }
+      return spaceAllowed - (spaceAllowed < 268435455 ? 4 : 5);
    }
 
    @Override
@@ -306,6 +281,14 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
       void flush() throws IOException {
       }
 
+      void close() throws IOException {
+         flush();
+      }
+
+      int remainingSpace() {
+         return Integer.MAX_VALUE;
+      }
+
       // high level ops, writing fields
 
       void writeUInt32Field(int fieldNumber, int value) throws IOException {
@@ -353,6 +336,20 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
       abstract void writeBytes(byte[] value, int offset, int length) throws IOException;
 
       abstract void writeBytes(ByteBuffer value) throws IOException;
+
+      boolean supportsFixedVarint() {
+         return false;
+      }
+   }
+
+   abstract static class FixedVarintEncoder extends Encoder {
+      abstract int skipFixedVarint();
+
+      abstract void writePositiveFixedVarint(int pos);
+      @Override
+      boolean supportsFixedVarint() {
+         return true;
+      }
    }
 
    /**
@@ -425,7 +422,7 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
    /**
     * Writes to a user provided byte array.
     */
-   private static class ByteArrayEncoder extends Encoder {
+   private static class ByteArrayEncoder extends FixedVarintEncoder {
 
       private final byte[] array;
 
@@ -457,6 +454,7 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
          this.pos = offset;
       }
 
+      @Override
       protected final int remainingSpace() {
          return limit - pos;
       }
@@ -594,6 +592,26 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
             throw log.outOfWriteBufferSpace(e);
          }
       }
+
+      @Override
+      int skipFixedVarint() {
+         int prev = pos;
+         pos += 5;
+         return prev;
+      }
+
+      @Override
+      void writePositiveFixedVarint(int pos) {
+         TagWriterImpl.writePositiveFixedVarint(array, pos, this.pos - pos - 5);
+      }
+   }
+
+   public static void writePositiveFixedVarint(byte[] array, int pos, int length) {
+      array[pos++] = (byte) (length & 0x7F | 0x80);
+      array[pos++] = (byte) ((length >>> 7) & 0x7F | 0x80);
+      array[pos++] = (byte) ((length >>> 14) & 0x7F | 0x80);
+      array[pos++] = (byte) ((length >>> 21) & 0x7F | 0x80);
+      array[pos] = (byte) ((length >>> 28) & 0x7F);
    }
 
    /**
@@ -722,7 +740,7 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
       }
    }
 
-   private static class OutputStreamNoBufferEncoder extends Encoder {
+   private static class OutputStreamNoBufferEncoder extends FixedVarintEncoder {
 
       private final OutputStream out;
 
@@ -806,11 +824,28 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
          super.flush();
          out.flush();
       }
+
+      @Override
+      int skipFixedVarint() {
+         return ((ByteArrayOutputStreamEx) out).skipFixedVarint();
+      }
+
+      @Override
+      void writePositiveFixedVarint(int pos) {
+         ((ByteArrayOutputStreamEx) out).writePositiveFixedVarint(pos);
+      }
+
+      @Override
+      boolean supportsFixedVarint() {
+         return out instanceof ByteArrayOutputStreamEx;
+      }
    }
 
    /**
     * Writes to an {@link OutputStream} and performs internal buffering to minimize the number of stream writes.
+    * @Deprecated this is to be removed in next major
     */
+   @Deprecated
    private static final class OutputStreamEncoder extends Encoder {
 
       private final ByteArrayEncoder buffer;
@@ -920,6 +955,204 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
       @Override
       void flush() throws IOException {
          buffer.flushToStream(out);
+      }
+   }
+
+   private static class FixedVarintWrappedEncoder extends Encoder {
+      private final FixedVarintEncoder parentEncoder;
+      private final int originalPos;
+      private boolean closed;
+
+      private FixedVarintWrappedEncoder(FixedVarintEncoder parentEncoder) {
+         this.parentEncoder = parentEncoder;
+         this.originalPos = parentEncoder.skipFixedVarint();
+      }
+
+      @Override
+      void writeVarint32(int value) throws IOException {
+         parentEncoder.writeVarint32(value);
+      }
+
+      @Override
+      void writeVarint64(long value) throws IOException {
+         parentEncoder.writeVarint64(value);
+      }
+
+      @Override
+      void writeFixed32(int value) throws IOException {
+         parentEncoder.writeFixed32(value);
+      }
+
+      @Override
+      void writeFixed64(long value) throws IOException {
+         parentEncoder.writeFixed64(value);
+      }
+
+      @Override
+      void writeByte(byte value) throws IOException {
+         parentEncoder.writeByte(value);
+      }
+
+      @Override
+      void writeBytes(byte[] value, int offset, int length) throws IOException {
+         parentEncoder.writeBytes(value, offset, length);
+      }
+
+      @Override
+      void writeBytes(ByteBuffer value) throws IOException {
+         parentEncoder.writeBytes(value);
+      }
+
+      @Override
+      void close() throws IOException {
+         if (!closed) {
+            closed = true;
+            parentEncoder.writePositiveFixedVarint(originalPos);
+         }
+      }
+   }
+
+   private static class ArrayBasedWrappedEncoder extends Encoder {
+      private final int maxSize;
+      private final Encoder parentEncoder;
+      private final int number;
+      private int pos = 0;
+      private byte[] bytes;
+      private boolean closed;
+
+      public ArrayBasedWrappedEncoder(int maxSize, Encoder parentEncoder, int number) {
+         this.maxSize = maxSize;
+         this.parentEncoder = parentEncoder;
+         this.number = number;
+         bytes = new byte[Math.min(maxSize, 32)];
+      }
+
+      @Override
+      void writeVarint32(int value) throws IOException {
+         ensureSize(5);
+         try {
+            while (true) {
+               if ((value & 0xFFFFFF80) == 0) {
+                  bytes[pos++] = (byte) value;
+                  break;
+               } else {
+                  bytes[pos++] = (byte) (value & 0x7F | 0x80);
+                  value >>>= 7;
+               }
+            }
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeVarint64(long value) throws IOException {
+         ensureSize(10);
+         try {
+            while (true) {
+               if ((value & 0xFFFFFFFFFFFFFF80L) == 0) {
+                  bytes[pos++] = (byte) value;
+                  break;
+               } else {
+                  bytes[pos++] = (byte) ((int) value & 0x7F | 0x80);
+                  value >>>= 7;
+               }
+            }
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeFixed32(int value) throws IOException {
+         ensureSize(4);
+         try {
+            bytes[pos++] = (byte) (value & 0xFF);
+            bytes[pos++] = (byte) ((value >> 8) & 0xFF);
+            bytes[pos++] = (byte) ((value >> 16) & 0xFF);
+            bytes[pos++] = (byte) ((value >> 24) & 0xFF);
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeFixed64(long value) throws IOException {
+         ensureSize(8);
+         try {
+            bytes[pos++] = (byte) (value & 0xFF);
+            bytes[pos++] = (byte) ((value >> 8) & 0xFF);
+            bytes[pos++] = (byte) ((value >> 16) & 0xFF);
+            bytes[pos++] = (byte) ((value >> 24) & 0xFF);
+            bytes[pos++] = (byte) ((int) (value >> 32) & 0xFF);
+            bytes[pos++] = (byte) ((int) (value >> 40) & 0xFF);
+            bytes[pos++] = (byte) ((int) (value >> 48) & 0xFF);
+            bytes[pos++] = (byte) ((int) (value >> 56) & 0xFF);
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeByte(byte value) throws IOException {
+         ensureSize(1);
+         try {
+            bytes[pos++] = value;
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeBytes(byte[] value, int offset, int length) throws IOException {
+         ensureSize(length);
+         try {
+            System.arraycopy(value, offset, bytes, pos, length);
+            pos += length;
+         } catch (IndexOutOfBoundsException e) {
+            throw log.outOfWriteBufferSpace(e);
+         }
+      }
+
+      @Override
+      void writeBytes(ByteBuffer value) throws IOException {
+         int length = value.remaining();
+         ensureSize(length);
+         if (value.hasArray()) {
+            writeBytes(value.array(), value.arrayOffset() + value.position(), length);
+            value.position(value.position() + length);
+         } else {
+            try {
+               value.get(bytes, pos, length);
+               pos += length;
+            } catch (IndexOutOfBoundsException e) {
+               throw log.outOfWriteBufferSpace(e);
+            }
+         }
+      }
+
+      @Override
+      void close() throws IOException {
+         if (!closed) {
+            closed = true;
+            parentEncoder.writeLengthDelimitedField(number, pos);
+            parentEncoder.writeBytes(bytes, 0, pos);
+         }
+      }
+
+      private void ensureSize(int possibleLength) {
+         int targetSize = pos + possibleLength;
+         int currentSize = bytes.length;
+         while (targetSize > currentSize) {
+            if (currentSize > maxSize) {
+               currentSize = maxSize;
+               break;
+            }
+            currentSize <<= 1;
+         }
+         if (currentSize != bytes.length) {
+            bytes = Arrays.copyOf(bytes, currentSize);
+         }
       }
    }
 }

--- a/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
@@ -2,7 +2,6 @@ package org.infinispan.protostream;
 
 import static org.infinispan.protostream.domain.Account.Currency.BRL;
 import static org.infinispan.protostream.domain.Account.Currency.USD;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -58,7 +57,8 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
 
       messageSize = ProtobufUtil.computeWrappedMessageSize(ctx, user);
 
-      assertEquals(expectedMessageSize, messageSize);
+      // Actual array is 4 bigger because of fixed Varint
+      assertEquals(expectedMessageSize, messageSize + 4);
    }
 
    @Test(expected = MalformedProtobufException.class)
@@ -118,7 +118,13 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
       byte[] userBytes2 = ProtobufUtil.toByteArray(ctx, new WrappedMessage(user));
 
       // assert that toWrappedByteArray works correctly as a shorthand for toByteArray on a WrappedMessage
-      assertArrayEquals(userBytes1, userBytes2);
+      assertWrappedArraysEqual(ctx, userBytes1, userBytes2);
+   }
+
+   public static void assertWrappedArraysEqual(ImmutableSerializationContext ctx, byte[] array1, byte[] array2) throws IOException {
+      Object user1 = ProtobufUtil.fromWrappedByteArray(ctx, array1);
+      Object user2 = ProtobufUtil.fromWrappedByteArray(ctx, array2);
+      assertEquals(user1, user2);
    }
 
    @Test
@@ -484,7 +490,7 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
       assertValid(json);
       byte[] bytes = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
       assertEquals(object, ProtobufUtil.fromWrappedByteArray(ctx, bytes));
-      assertArrayEquals(marshalled, bytes);
+      assertWrappedArraysEqual(ctx, marshalled, bytes);
    }
 
    private <T> void testJsonConversion(ImmutableSerializationContext ctx, T object) throws IOException {

--- a/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
@@ -57,8 +57,7 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
 
       messageSize = ProtobufUtil.computeWrappedMessageSize(ctx, user);
 
-      // Actual array is 4 bigger because of fixed Varint
-      assertEquals(expectedMessageSize, messageSize + 4);
+      assertEquals(expectedMessageSize, messageSize);
    }
 
    @Test(expected = MalformedProtobufException.class)

--- a/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/annotated_package/AnnotationOnPackageIntegrationTest.java
+++ b/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/annotated_package/AnnotationOnPackageIntegrationTest.java
@@ -1,17 +1,16 @@
 package org.infinispan.protostream.integrationtests.processor.annotated_package;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Arrays;
 import java.util.ServiceLoader;
 
 import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.ProtobufUtilTest;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
@@ -65,7 +64,7 @@ public class AnnotationOnPackageIntegrationTest {
       String json = ProtobufUtil.toCanonicalJSON(serCtx, userBytes, true);
       byte[] jsonBytes = ProtobufUtil.fromCanonicalJSON(serCtx, new StringReader(json));
 
-      assertArrayEquals(userBytes, jsonBytes);
+      ProtobufUtilTest.assertWrappedArraysEqual(serCtx, userBytes, jsonBytes);
    }
 
    @AutoProtoSchemaBuilder(dependsOn = ReusableInitializer.class, includeClasses = DependentInitializer.C.class, service = true)


### PR DESCRIPTION
* Add new subWriter method to implement to allow reusing encoder instances
* Add some common default methods to the TagWriter/TagReader interfaces
* Add common way to write a fixed varint of 5 bytes

https://issues.redhat.com/browse/IPROTO-265
https://issues.redhat.com/browse/IPROTO-266

Also added changes to allow for custom Decoder/Encoder instances to be used instead of the supplied ones.