### PR TITLE
IPROTO-280 Byte and short not parsed into JSON

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/impl/JsonUtils.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/JsonUtils.java
@@ -700,6 +700,8 @@ public final class JsonUtils {
                case WRAPPED_ENUM:
                   wrappedEnum = (Integer) tagValue;
                   break;
+               case WrappedMessage.WRAPPED_BYTE:
+               case WrappedMessage.WRAPPED_SHORT:
                case WrappedMessage.WRAPPED_DOUBLE:
                case WrappedMessage.WRAPPED_FLOAT:
                case WrappedMessage.WRAPPED_INT64:

--- a/core/src/test/java/org/infinispan/protostream/domain/Numerics.java
+++ b/core/src/test/java/org/infinispan/protostream/domain/Numerics.java
@@ -1,0 +1,83 @@
+package org.infinispan.protostream.domain;
+
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+public class Numerics {
+
+   public Numerics() { }
+
+   @ProtoFactory
+   public Numerics(byte simpleByte, short simpleShort,
+                   int simpleInt, long simpleLong,
+                   float simpleFloat, double simpleDouble) {
+      this.simpleByte = simpleByte;
+      this.simpleShort = simpleShort;
+      this.simpleInt = simpleInt;
+      this.simpleLong = simpleLong;
+      this.simpleFloat = simpleFloat;
+      this.simpleDouble = simpleDouble;
+   }
+
+   @ProtoField(number = 1, defaultValue = "0")
+   byte simpleByte;
+
+   @ProtoField(number = 2, defaultValue = "0")
+   short simpleShort;
+
+   @ProtoField(number = 3, defaultValue = "0")
+   int simpleInt;
+
+   @ProtoField(number = 4, defaultValue = "0")
+   long simpleLong;
+
+   @ProtoField(number = 5, defaultValue = "0")
+   float simpleFloat;
+
+   @ProtoField(number = 6, defaultValue = "0")
+   double simpleDouble;
+
+   public byte simpleByte() {
+      return simpleByte;
+   }
+
+   public short simpleShort() {
+      return simpleShort;
+   }
+
+   public int simpleInt() {
+      return simpleInt;
+   }
+
+   public long simpleLong() {
+      return simpleLong;
+   }
+
+   public float simpleFloat() {
+      return simpleFloat;
+   }
+
+   public double simpleDouble() {
+      return simpleDouble;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Numerics numerics = (Numerics) o;
+      return simpleByte == numerics.simpleByte
+            && simpleShort == numerics.simpleShort
+            && simpleInt == numerics.simpleInt
+            && simpleLong == numerics.simpleLong
+            && Float.compare(simpleFloat, numerics.simpleFloat) == 0
+            && Double.compare(simpleDouble, numerics.simpleDouble) == 0;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(simpleByte, simpleShort, simpleInt, simpleLong, simpleFloat, simpleDouble);
+   }
+}

--- a/core/src/test/java/org/infinispan/protostream/domain/marshallers/MarshallerRegistration.java
+++ b/core/src/test/java/org/infinispan/protostream/domain/marshallers/MarshallerRegistration.java
@@ -23,5 +23,6 @@ public class MarshallerRegistration {
       ctx.registerMarshaller(new LimitsMarshaller());
       ctx.registerMarshaller(new TransactionMarshaller());
       ctx.registerMarshaller(new CurrencyMarshaller());
+      ctx.registerMarshaller(new NumericsMarshaller());
    }
 }

--- a/core/src/test/java/org/infinispan/protostream/domain/marshallers/NumericsMarshaller.java
+++ b/core/src/test/java/org/infinispan/protostream/domain/marshallers/NumericsMarshaller.java
@@ -1,0 +1,41 @@
+package org.infinispan.protostream.domain.marshallers;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.MessageMarshaller;
+import org.infinispan.protostream.domain.Numerics;
+
+public class NumericsMarshaller implements MessageMarshaller<Numerics> {
+
+   @Override
+   public Class<? extends Numerics> getJavaClass() {
+      return Numerics.class;
+   }
+
+   @Override
+   public String getTypeName() {
+      return "sample_bank_account.Numerics";
+   }
+
+   @Override
+   public Numerics readFrom(ProtoStreamReader reader) throws IOException {
+      return new Numerics(
+            reader.readInt("simpleByte").byteValue(),
+            reader.readInt("simpleShort").shortValue(),
+            reader.readInt("simpleInt"),
+            reader.readLong("simpleLong"),
+            reader.readFloat("simpleFloat"),
+            reader.readDouble("simpleDouble")
+      );
+   }
+
+   @Override
+   public void writeTo(ProtoStreamWriter writer, Numerics numerics) throws IOException {
+      writer.writeInt("simpleByte", numerics.simpleByte());
+      writer.writeInt("simpleShort", numerics.simpleShort());
+      writer.writeInt("simpleInt", numerics.simpleInt());
+      writer.writeLong("simpleLong", numerics.simpleLong());
+      writer.writeFloat("simpleFloat", numerics.simpleFloat());
+      writer.writeDouble("simpleDouble", numerics.simpleDouble());
+   }
+}

--- a/core/src/test/resources/sample_bank_account/bank.proto
+++ b/core/src/test/resources/sample_bank_account/bank.proto
@@ -220,6 +220,39 @@ message Transaction {
    required bool isValid = 9;
 }
 
+message Numerics {
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional int32 simpleByte = 1;
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional int32 simpleShort = 2;
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional int32 simpleInt = 3;
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional int64 simpleLong = 4;
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional float simpleFloat = 5;
+
+   /**
+    * @Field(store = Store.YES)
+    */
+   optional double simpleDouble = 6;
+}
+
 /**
  * An array of int.
  */


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-280

The byte/short has a representation in protostream that knows the underlying type. In JSON, it becomes `{"_type":"int32","_value":1}`, but if we parse the JSON back to the protostream representation, the byte array is not the same, as it transforms the value into an int. TBH, I am unsure we can make the byte array the same without breaking compatibility. The problem is that the JSON representation loses the notion of the typing.
