### PR TITLE
fix: PROTO_SCHEMA generated value with unclosed string literal

### DIFF
--- a/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AutoProtoSchemaBuilderAnnotationProcessor.java
+++ b/processor/src/main/java/org/infinispan/protostream/annotations/impl/processor/AutoProtoSchemaBuilderAnnotationProcessor.java
@@ -633,26 +633,11 @@ public final class AutoProtoSchemaBuilderAnnotationProcessor extends AbstractPro
    }
 
    private String makeStringLiteral(String s) {
-      StringBuilder sb = new StringBuilder(s.length() + 2);
-      sb.append('\"');
-      for (int i = 0; i < s.length(); i++) {
-         char ch = s.charAt(i);
-         switch (ch) {
-            case '\n':
-               sb.append("\\n\" +\n\"");
-               break;
-            case '\"':
-               sb.append("\\\"");
-               break;
-            case '\\':
-               sb.append("\\\\");
-               break;
-            default:
-               sb.append(ch);
-         }
-      }
-      sb.append('\"');
-      return sb.toString();
+      return new StringBuilder(s.length() + 8)
+              .append("\"\"\"\n")
+              .append(s)
+              .append("\n\"\"\"")
+              .toString();
    }
 
    private String makeNestedClassName(TypeElement e, String className) {


### PR DESCRIPTION
The issue:
-  The value being generated for constant PROTO_SCHEMA was adding odd quotes in the middle of the string. So the generated value could not be compiled.
![image](https://github.com/infinispan/protostream/assets/5123320/20abbac3-dc60-4803-aa4d-01c4f172a528)


The cause: 
- The method makeStringLiteral, used to generate the value for PROTO_SCHEMA, was building the string iterating char by char and appending line breaks, slashes, quotes and plus signs in order to transform the string to literal keeping that as multi line.

Suggested fix: 
- The method was refactored to use java builtin multi-line string support with triple quotes (""" ..._multi line string here_... """). So, no need to escape line breaks any more.