### PR TITLE
IPROTO-351 TypeId must be parsed before the compatibility check

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
@@ -288,7 +288,6 @@ public final class FileDescriptor {
    }
 
    private void collectDescriptors(Descriptor descriptor, ResolutionContext resolutionContext) {
-      descriptor.setFileDescriptor(this);
       fileNamespace.put(descriptor.getFullName(), descriptor);
       resolutionContext.addGenericDescriptor(descriptor);
 
@@ -301,7 +300,6 @@ public final class FileDescriptor {
    }
 
    private void collectEnumDescriptors(EnumDescriptor enumDescriptor, ResolutionContext resolutionContext) {
-      enumDescriptor.setFileDescriptor(this);
       fileNamespace.put(enumDescriptor.getFullName(), enumDescriptor);
       resolutionContext.addGenericDescriptor(enumDescriptor);
    }
@@ -423,6 +421,14 @@ public final class FileDescriptor {
       if (!errors.isEmpty()) {
          throw Log.LOG.incompatibleSchemaChanges(String.join("\n", errors));
       }
+   }
+
+   public void parseAnnotations() {
+      if (configuration == null) {
+         throw new IllegalStateException("FileDescriptor.setConfiguration() must be invoked before parsing the annotations");
+      }
+      messageTypes.forEach(descriptor -> descriptor.setFileDescriptor(this));
+      enumTypes.forEach(enumDescriptor -> enumDescriptor.setFileDescriptor(this));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/protostream/descriptors/ProtoLock.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/ProtoLock.java
@@ -127,6 +127,7 @@ public class ProtoLock {
          messageBuilders.values().forEach(fdb::addMessage);
          FileDescriptor fd = fdb.build();
          fd.setConfiguration(configuration);
+         fd.parseAnnotations();
          descriptors.add(fd);
       }
       return new ProtoLock(descriptors);

--- a/core/src/main/java/org/infinispan/protostream/impl/parser/ProtostreamProtoParser.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/parser/ProtostreamProtoParser.java
@@ -45,6 +45,7 @@ public final class ProtostreamProtoParser {
          try {
             FileDescriptor fileDescriptor = ProtoParser.parse(fileName, new StringReader(entry.getValue()), configuration);
             fileDescriptor.setConfiguration(configuration);
+            fileDescriptor.parseAnnotations();
             fileDescriptorMap.put(fileName, fileDescriptor);
          } catch (DescriptorParserException e) {
             reportParsingError(fileDescriptorSource, fileDescriptorMap, fileName, e);

--- a/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/marshaller/GeneratedMarshallerTest.java
+++ b/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/marshaller/GeneratedMarshallerTest.java
@@ -60,6 +60,16 @@ public class GeneratedMarshallerTest {
    }
 
    @Test
+   public void testRegisterTwice() {
+      var ctx = ProtobufUtil.newSerializationContext();
+      MapSchema.INSTANCE.registerSchema(ctx);
+      MapSchema.INSTANCE.registerMarshallers(ctx);
+
+      MapSchema.INSTANCE.registerSchema(ctx);
+      MapSchema.INSTANCE.registerMarshallers(ctx);
+   }
+
+   @Test
    public void testMaps() throws IOException {
       var ctx = ProtobufUtil.newSerializationContext();
       MapSchema.INSTANCE.registerSchema(ctx);

--- a/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/marshaller/model/SimpleEnum.java
+++ b/integrationtests/src/test/java/org/infinispan/protostream/integrationtests/processor/marshaller/model/SimpleEnum.java
@@ -1,7 +1,9 @@
 package org.infinispan.protostream.integrationtests.processor.marshaller.model;
 
 import org.infinispan.protostream.annotations.Proto;
+import org.infinispan.protostream.annotations.ProtoTypeId;
 
+@ProtoTypeId(111111) // large enough so it does not conflict
 @Proto
 public enum SimpleEnum {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-351

I don't know if this is the best way to do it and the method name is not the best. Suggestions are welcome. 