### PR TITLE
IPROTO-383 Allow proto-schema-compatibility-maven-plugin to compare a…

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -329,6 +329,12 @@
 
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${version.plugin.api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>${version.plugin.api}</version>
                 <scope>provided</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/IPROTO-383

@tristantarrant This is needed for the Keycloak release, where we intend to eventually check schema compatibility against multiple branches.

Tested using Infinispan commons and the following configuration:

```xml
            <plugin>
               <groupId>org.infinispan.protostream</groupId>
               <artifactId>proto-schema-compatibility-maven-plugin</artifactId>
               <version>5.0.9-SNAPSHOT</version>
               <configuration>
                  <commitProtoLock>${commitProtoLockChanges}</commitProtoLock>
                  <remoteLockFiles>https://raw.githubusercontent.com/infinispan/infinispan/refs/heads/main/commons/all/proto.lock</remoteLockFiles>
               </configuration>
            </plugin>
```
Changing the branch of the remoteLockFiles to `14.0.x` will cause the check to fail as expected.