### PR TITLE
Optimize nested writers during marshalling.

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/RandomAccessOutputStream.java
+++ b/core/src/main/java/org/infinispan/protostream/RandomAccessOutputStream.java
@@ -112,6 +112,14 @@ public interface RandomAccessOutputStream extends Closeable {
    void write(int position, byte[] b, int off, int len) throws IOException;
 
    /**
+    * Moves bytes forward in the internal data stream.
+    * @param startPos the starting position of the existing data
+    * @param length how many bytes to be moved
+    * @param newPos the new starting position of the data
+    */
+   void move(int startPos, int length, int newPos);
+
+   /**
     * Write all bytes in this stream to the provided {@link DataOutput} stream
     * @param output the stream to write this stream's bytes to
     */

--- a/core/src/main/java/org/infinispan/protostream/TagWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/TagWriter.java
@@ -9,10 +9,15 @@ import org.infinispan.protostream.descriptors.WireType;
  * @author anistor@redhat.com
  * @since 4.4
  */
-public interface TagWriter {
+public interface TagWriter extends AutoCloseable {
 
    // start low level ops
    void flush() throws IOException;
+
+   @Override
+   default void close() throws IOException {
+      flush();
+   }
 
    void writeTag(int number, int wireType) throws IOException;
 
@@ -62,4 +67,14 @@ public interface TagWriter {
 
    void writeBytes(int number, byte[] value, int offset, int length) throws IOException;
    // end high level ops
+
+   /**
+    * Used to write a sub message that can be optimized by implementation. When the sub writer is complete, flush
+    * should also be invoked to ensure all data is pushed to the parent writer as necessary.
+    * @param number the field type number
+    * @param nested if the subWriter is nested in another message
+    * @return a writer that will handle the nested message writing
+    * @throws IOException if there is an exception while writing data
+    */
+   TagWriter subWriter(int number, boolean nested) throws IOException;
 }

--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/GeneratedMarshallerBase.java
@@ -3,11 +3,9 @@ package org.infinispan.protostream.annotations.impl;
 import java.io.IOException;
 
 import org.infinispan.protostream.ProtobufTagMarshaller;
-import org.infinispan.protostream.RandomAccessOutputStream;
+import org.infinispan.protostream.TagWriter;
 import org.infinispan.protostream.impl.BaseMarshallerDelegate;
 import org.infinispan.protostream.impl.Log;
-import org.infinispan.protostream.impl.RandomAccessOutputStreamImpl;
-import org.infinispan.protostream.impl.TagWriterImpl;
 
 /**
  * Base class for generated message marshallers. Provides some handy helper methods.
@@ -46,30 +44,8 @@ public class GeneratedMarshallerBase {
       if (ctx.depth() >= maxNestedMessageDepth) {
          throw log.maxNestedMessageDepth(maxNestedMessageDepth, message.getClass());
       }
-      try (NestedWriter nested = new NestedWriter(ctx, fieldNumber)) {
-         writeMessage(marshallerDelegate, nested.writer, message);
-      }
-   }
-
-   public static class NestedWriter implements AutoCloseable {
-      final RandomAccessOutputStream baos;
-      final TagWriterImpl writer;
-      private final ProtobufTagMarshaller.WriteContext ctx;
-      private final int fieldNumber;
-
-      public NestedWriter(ProtobufTagMarshaller.WriteContext ctx, int fieldNumber) {
-         this.ctx = ctx;
-         this.fieldNumber = fieldNumber;
-         this.baos = new RandomAccessOutputStreamImpl();
-         this.writer = TagWriterImpl.newNestedInstance(ctx, baos);
-      }
-
-      public TagWriterImpl getWriter() {
-         return writer;
-      }
-
-      public void close() throws IOException {
-         ctx.getWriter().writeBytes(fieldNumber, baos.getByteBuffer());
+      try (TagWriter nestedWriter = ctx.getWriter().subWriter(fieldNumber, true)) {
+         marshallerDelegate.marshall((ProtobufTagMarshaller.WriteContext) nestedWriter, null, message);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/protostream/descriptors/WireType.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/WireType.java
@@ -30,6 +30,8 @@ public enum WireType {
    public static final int FIXED_32_SIZE = 4;
    public static final int FIXED_64_SIZE = 8;
    public static final int MAX_VARINT_SIZE = 10;
+   // Similar to MAX_VARINT_SIZE except to be used for fields that are only ever used as Java primitive int values
+   public static final int MAX_INT_VARINT_SIZE = 5;
 
    /**
     * The lower 3 bits of the 32 bit tag are used for encoding the wire type.

--- a/core/src/main/java/org/infinispan/protostream/impl/RandomAccessOutputStreamImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/RandomAccessOutputStreamImpl.java
@@ -64,6 +64,13 @@ public class RandomAccessOutputStreamImpl extends OutputStream implements Random
    }
 
    @Override
+   public void move(int startPos, int length, int newPos) {
+      assert startPos < newPos;
+      ensureCapacity(newPos + length);
+      System.arraycopy(buf, startPos, buf, newPos, length);
+   }
+
+   @Override
    public void ensureCapacity(int capacity) {
       if (buf == null) {
          buf = new byte[Math.max(MIN_SIZE, capacity)];

--- a/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
@@ -523,4 +523,28 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
          fail("Invalid JSON found : " + json);
       }
    }
+
+   @Test
+   public void testLongNestedMessage() throws Exception {
+      ImmutableSerializationContext ctx = createContext();
+
+      User user = new User();
+      user.setId(1);
+      user.setName("John");
+      user.setSurname("Batman");
+      user.setGender(User.Gender.MALE);
+      user.setAccountIds(new HashSet<>(Arrays.asList(1, 3)));
+      user.setAddresses(Arrays.asList(
+            new Address("Old Street", "XYZ42", -12),
+            // This address will serialize to be longer than 127 requiring more than 1 byte per size
+            new Address("Bond Street".repeat(12), "W23", 2),
+            new Address("Long Foo".repeat(20), "Y791", 23)
+      ));
+
+      byte[] bytes = ProtobufUtil.toWrappedByteArray(ctx, user);
+
+      User userResult = ProtobufUtil.fromWrappedByteArray(ctx, bytes);
+
+      assertEquals(user, userResult);
+   }
 }


### PR DESCRIPTION
Fixes #427

This PR introduces a new method to TagWriter and Encoder to allow those classes control the TagWriter and Encoder that are created whenever a sub message is found. It removes all manual creations of TagWriters in those places and replaces with calls to the new method.

The first commit does that refactoring and by default has all Writer/Encoders use OutputStreamRandomAccessEncoder as was done prior. The big difference is the new encoders will cache previously used sub encoders so they will not have to recreate them for multiple nested messages at the same depth.

The second commit takes this one step further by introducing a move method to the RandomAccessOutputStream by allowing it to move bytes within the same stream. This allows us to not have to create any additional byte[] and instead it reuses the same one from the parent.

The third commit is just one to remove some unneeded computations for var ints where it was finding the exact size to ensure the byte[] was large enough. In that case there is no real reason to incur the true cost and just assume 5 for the worst case. In many cases this will not cause a resize and the cases when it does it most likely would have had to resize for the next value anyways.

The fourth commit takes the second commit a step further by actually reusing the same Encoder instance for all nested messages. Instead the previous sizes are stored in an int[] and when close is invoked it takes the last size value to write to it, further reducing allocation costs.