### PR TITLE
[#452] Use VarHandle to write fixed 32 and 64 bit value

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/RandomAccessOutputStream.java
+++ b/core/src/main/java/org/infinispan/protostream/RandomAccessOutputStream.java
@@ -124,4 +124,42 @@ public interface RandomAccessOutputStream extends Closeable {
     * @param output the stream to write this stream's bytes to
     */
    void copyTo(DataOutput output) throws IOException;
+
+   /**
+    * Write a 32-bit value, starting into {@code position} using little endian byte order.
+    * <p>
+    * The implementation does not require updating the internal position as the caller should invoke
+    * {@link #setPosition(int)} at some point after this method invocation.
+    *
+    * @param position The position to start writing.
+    * @param value    The 32-bit value to write.
+    * @throws IOException if an IO error occurs.
+    */
+   default void writeFixed32Direct(int position, int value) throws IOException {
+      write(position, (byte) (value));
+      write(position + 1, (byte) (value >> 8));
+      write(position + 2, (byte) (value >> 16));
+      write(position + 3, (byte) (value >> 24));
+   }
+
+   /**
+    * Write a 64-bit value, starting into {@code position} using little endian byte order.
+    * <p>
+    * The implementation does not require updating the internal position as the caller should invoke
+    * {@link #setPosition(int)} at some point after this method invocation.
+    *
+    * @param position The position to start writing.
+    * @param value    The 64-bit value to write.
+    * @throws IOException if an IO error occurs.
+    */
+   default void writeFixed64Direct(int position, long value) throws IOException {
+      write(position, (byte) (value));
+      write(position + 1, (byte) (value >> 8));
+      write(position + 2, (byte) (value >> 16));
+      write(position + 3, (byte) (value >> 24));
+      write(position + 4, (byte) (value >> 32));
+      write(position + 5, (byte) (value >> 40));
+      write(position + 6, (byte) (value >> 48));
+      write(position + 7, (byte) (value >> 56));
+   }
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/RandomAccessOutputStreamImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/RandomAccessOutputStreamImpl.java
@@ -114,4 +114,14 @@ public class RandomAccessOutputStreamImpl extends OutputStream implements Random
    public void copyTo(DataOutput output) throws IOException {
       output.write(buf, 0, pos);
    }
+
+   @Override
+   public void writeFixed32Direct(int position, int value) {
+      VarHandlesUtil.INT.set(buf, position, value);
+   }
+
+   @Override
+   public void writeFixed64Direct(int position, long value) {
+      VarHandlesUtil.LONG.set(buf, position, value);
+   }
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/TagReaderImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/TagReaderImpl.java
@@ -476,7 +476,7 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       }
 
       @Override
-      byte[] getBufferArray() throws IOException {
+      byte[] getBufferArray() {
          return array;
       }
 
@@ -562,10 +562,7 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       @Override
       int readFixed32() throws IOException {
          try {
-            int value = (array[pos] & 0xFF)
-                  | ((array[pos + 1] & 0xFF) << 8)
-                  | ((array[pos + 2] & 0xFF) << 16)
-                  | ((array[pos + 3] & 0xFF) << 24);
+            int value = (int) VarHandlesUtil.INT.get(array, pos);
             pos += FIXED_32_SIZE;
             return value;
          } catch (ArrayIndexOutOfBoundsException e) {
@@ -576,14 +573,7 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       @Override
       long readFixed64() throws IOException {
          try {
-            long value = (array[pos] & 0xFFL)
-                  | ((array[pos + 1] & 0xFFL) << 8)
-                  | ((array[pos + 2] & 0xFFL) << 16)
-                  | ((array[pos + 3] & 0xFFL) << 24)
-                  | ((array[pos + 4] & 0xFFL) << 32)
-                  | ((array[pos + 5] & 0xFFL) << 40)
-                  | ((array[pos + 6] & 0xFFL) << 48)
-                  | ((array[pos + 7] & 0xFFL) << 56);
+            long value = (long) VarHandlesUtil.LONG.get(array, pos);
             pos += FIXED_64_SIZE;
             return value;
          } catch (ArrayIndexOutOfBoundsException e) {
@@ -690,7 +680,7 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       }
 
       @Override
-      byte[] getBufferArray() throws IOException {
+      byte[] getBufferArray() {
          return buf.array();
       }
 
@@ -721,7 +711,7 @@ public final class TagReaderImpl implements TagReader, ProtobufTagMarshaller.Rea
       ByteBuffer readRawByteBuffer(int length) throws IOException {
          if (length > 0 && length <= end - buf.position()) {
             // apparently redundant cast, needed just for Java 8 binary compat, not needed for 9+
-            ByteBuffer byteBuffer = (ByteBuffer) buf.slice().limit(length);
+            ByteBuffer byteBuffer = buf.slice().limit(length);
             buf.position(buf.position() + length);
             return byteBuffer;
          }

--- a/core/src/main/java/org/infinispan/protostream/impl/TagWriterImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/TagWriterImpl.java
@@ -1173,8 +1173,8 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
          out.ensureCapacity(pos + MAX_INT_VARINT_SIZE + FIXED_32_SIZE);
 
          pos = writeVarInt32Direct(pos, tag);
-         pos = writeFixed32Direct(pos, value);
-         out.setPosition(pos);
+         out.writeFixed32Direct(pos, value);
+         out.setPosition(pos + FIXED_32_SIZE);
       }
 
       @Override
@@ -1184,8 +1184,8 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
          out.ensureCapacity(pos + MAX_INT_VARINT_SIZE + FIXED_64_SIZE);
 
          pos = writeVarInt32Direct(pos, tag);
-         pos = writeFixed64Direct(pos, value);
-         out.setPosition(pos);
+         out.writeFixed64Direct(pos, value);
+         out.setPosition(pos + FIXED_64_SIZE);
       }
 
       @Override
@@ -1262,18 +1262,20 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
 
       @Override
       void writeFixed32(int value) throws IOException {
-         int pos = out.getPosition();
-         out.ensureCapacity(pos + FIXED_32_SIZE);
-         pos = writeFixed32Direct(pos, value);
-         out.setPosition(pos);
+         var pos = out.getPosition();
+         var newPos = pos + FIXED_32_SIZE;
+         out.ensureCapacity(newPos);
+         out.writeFixed32Direct(pos, value);
+         out.setPosition(newPos);
       }
 
       @Override
       void writeFixed64(long value) throws IOException {
-         int pos = out.getPosition();
-         out.ensureCapacity(pos + FIXED_64_SIZE);
-         pos = writeFixed64Direct(pos, value);
-         out.setPosition(pos);
+         var pos = out.getPosition();
+         var newPos = pos + FIXED_64_SIZE;
+         out.ensureCapacity(newPos);
+         out.writeFixed64Direct(pos, value);
+         out.setPosition(newPos);
       }
 
       @Override
@@ -1332,26 +1334,6 @@ public final class TagWriterImpl implements TagWriter, ProtobufTagMarshaller.Wri
          startPos = writeVarInt32Direct(startPos, utf8buffer.length);
          out.write(startPos, utf8buffer);
          out.setPosition(startPos + utf8buffer.length);
-      }
-
-      private int writeFixed32Direct(int i, int value) throws IOException {
-         out.write(i++, (byte) (value & 0xFF));
-         out.write(i++, (byte) ((value >> 8) & 0xFF));
-         out.write(i++, (byte) ((value >> 16) & 0xFF));
-         out.write(i++, (byte) ((value >> 24) & 0xFF));
-         return i;
-      }
-
-      private int writeFixed64Direct(int i, long value) throws IOException {
-         out.write(i++, (byte) (value & 0xFF));
-         out.write(i++, (byte) ((value >> 8) & 0xFF));
-         out.write(i++, (byte) ((value >> 16) & 0xFF));
-         out.write(i++, (byte) ((value >> 24) & 0xFF));
-         out.write(i++, (byte) ((int) (value >> 32) & 0xFF));
-         out.write(i++, (byte) ((int) (value >> 40) & 0xFF));
-         out.write(i++, (byte) ((int) (value >> 48) & 0xFF));
-         out.write(i++, (byte) ((int) (value >> 56) & 0xFF));
-         return i;
       }
 
       int writeVarInt32Direct(int i, int value) throws IOException {

--- a/core/src/main/java/org/infinispan/protostream/impl/VarHandlesUtil.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/VarHandlesUtil.java
@@ -1,0 +1,14 @@
+package org.infinispan.protostream.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+public final class VarHandlesUtil {
+
+    private VarHandlesUtil() {}
+
+    // protobuf encoding is little endian
+    public static final VarHandle LONG = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+    public static final VarHandle INT = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+}


### PR DESCRIPTION
Closes #452 

The JMH Result using the UUID (uses 2 fixed 64 bits) shows improvements around 3%~14% when compared with 6.0.0.Dev06

```
-- This Pull Request

Benchmark                                      (byteArrayOrStream)  Mode  Cnt    Score   Error  Units
ProtostreamBenchmark.testMarshallUUID                         true  avgt    6  193.928 ± 5.406  ns/op
ProtostreamBenchmark.testMarshallUUID:async                   true  avgt           NaN            ---
ProtostreamBenchmark.testMarshallUUID                        false  avgt    6   46.885 ± 2.137  ns/op
ProtostreamBenchmark.testMarshallUUID:async                  false  avgt           NaN            ---
ProtostreamBenchmark.testSizedUUID                            true  avgt    6   40.430 ± 2.213  ns/op
ProtostreamBenchmark.testSizedUUID:async                      true  avgt           NaN            ---
ProtostreamBenchmark.testSizedUUID                           false  avgt    6   41.982 ± 2.051  ns/op
ProtostreamBenchmark.testSizedUUID:async                     false  avgt           NaN            ---
ProtostreamBenchmark.testUnmarshallUUID                       true  avgt    6   61.882 ± 1.778  ns/op
ProtostreamBenchmark.testUnmarshallUUID:async                 true  avgt           NaN            ---
ProtostreamBenchmark.testUnmarshallUUID                      false  avgt    6  108.089 ± 2.805  ns/op
ProtostreamBenchmark.testUnmarshallUUID:async                false  avgt           NaN            ---
```

```
-- 6.0.0.Dev06

Benchmark                                      (byteArrayOrStream)  Mode  Cnt    Score   Error  Units
ProtostreamBenchmark.testMarshallUUID                         true  avgt    6  227.985 ± 8.478  ns/op
ProtostreamBenchmark.testMarshallUUID:async                   true  avgt           NaN            ---
ProtostreamBenchmark.testMarshallUUID                        false  avgt    6   50.599 ± 4.434  ns/op
ProtostreamBenchmark.testMarshallUUID:async                  false  avgt           NaN            ---
ProtostreamBenchmark.testSizedUUID                            true  avgt    6   39.868 ± 1.316  ns/op
ProtostreamBenchmark.testSizedUUID:async                      true  avgt           NaN            ---
ProtostreamBenchmark.testSizedUUID                           false  avgt    6   40.452 ± 1.736  ns/op
ProtostreamBenchmark.testSizedUUID:async                     false  avgt           NaN            ---
ProtostreamBenchmark.testUnmarshallUUID                       true  avgt    6   65.925 ± 11.553  ns/op
ProtostreamBenchmark.testUnmarshallUUID:async                 true  avgt           NaN             ---
ProtostreamBenchmark.testUnmarshallUUID                      false  avgt    6  112.129 ±  4.389  ns/op
ProtostreamBenchmark.testUnmarshallUUID:async                false  avgt           NaN             ---
``` 

Edit, updated the `testUnmarshallUUID` results as I forgot to respect the `byteArrayOrStream` value. 