### PR TITLE
[5.0.x] [#405] Backport JSON parse for Instant

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
+++ b/core/src/main/java/org/infinispan/protostream/WrappedMessage.java
@@ -3,6 +3,7 @@ package org.infinispan.protostream;
 import org.infinispan.protostream.containers.ElementContainerAdapter;
 import org.infinispan.protostream.containers.IndexedElementContainerAdapter;
 import org.infinispan.protostream.containers.IterableElementContainerAdapter;
+import org.infinispan.protostream.descriptors.GenericDescriptor;
 import org.infinispan.protostream.descriptors.WireType;
 import org.infinispan.protostream.impl.BaseMarshallerDelegate;
 import org.infinispan.protostream.impl.ByteArrayOutputStreamEx;
@@ -13,8 +14,10 @@ import org.infinispan.protostream.impl.TagWriterImpl;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -44,6 +47,11 @@ import java.util.Objects;
  * @since 1.0
  */
 public final class WrappedMessage {
+
+   private static final Collection<Class<?>> WRAPPED_KNOWN_TYPES = List.of(
+         Instant.class,
+         Date.class
+   );
 
    /**
     * The fully qualified Protobuf type name of this message.
@@ -715,6 +723,14 @@ public final class WrappedMessage {
       }
       var elementReader = TagReaderImpl.newInstance(ctx, in.readByteArray());
       return readMessage(ctx, elementReader, true);
+   }
+
+   public static boolean knownWrappedDescriptor(ImmutableSerializationContext ctx, GenericDescriptor descriptor) {
+      return WRAPPED_KNOWN_TYPES.stream()
+            .filter(ctx::canMarshall)
+            .map(ctx::getMarshaller)
+            .filter(Objects::nonNull)
+            .anyMatch(m -> ctx.getDescriptorByName(m.getTypeName()) == descriptor);
    }
 
    /**

--- a/types/src/main/java/org/infinispan/protostream/types/java/CommonTypes.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/CommonTypes.java
@@ -4,6 +4,8 @@ import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.annotations.ProtoSchema;
 import org.infinispan.protostream.types.java.math.BigDecimalAdapter;
 import org.infinispan.protostream.types.java.math.BigIntegerAdapter;
+import org.infinispan.protostream.types.java.time.DateAdapter;
+import org.infinispan.protostream.types.java.time.InstantAdapter;
 import org.infinispan.protostream.types.java.time.LocalDateAdapter;
 import org.infinispan.protostream.types.java.time.LocalDateTimeAdapter;
 import org.infinispan.protostream.types.java.time.LocalTimeAdapter;
@@ -37,6 +39,8 @@ import org.infinispan.protostream.types.java.util.UUIDAdapter;
             LocalDateAdapter.class,
             LocalDateTimeAdapter.class,
             LocalTimeAdapter.class,
+            DateAdapter.class,
+            InstantAdapter.class,
             MonthAdapter.class,
             MonthDayAdapter.class,
             OffsetTimeAdapter.class,

--- a/types/src/main/java/org/infinispan/protostream/types/java/time/DateAdapter.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/time/DateAdapter.java
@@ -1,0 +1,31 @@
+package org.infinispan.protostream.types.java.time;
+
+import java.util.Date;
+
+import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.descriptors.Type;
+
+/**
+ * Adapter to convert {@link Date} objects.
+ *
+ * <p>
+ * To allow backwards compatibility, this converter uses the same names as the serialization embedded in the
+ * {@link WrappedMessage}.
+ * </p>
+ */
+@ProtoAdapter(Date.class)
+public class DateAdapter {
+
+   @ProtoFactory
+   Date create(Long epoch) {
+      return new Date(epoch);
+   }
+
+   @ProtoField(number = WrappedMessage.WRAPPED_DATE_MILLIS, type = Type.INT64, name = "_value")
+   Long getEpoch(Date date) {
+      return date.getTime();
+   }
+}

--- a/types/src/main/java/org/infinispan/protostream/types/java/time/InstantAdapter.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/time/InstantAdapter.java
@@ -1,0 +1,36 @@
+package org.infinispan.protostream.types.java.time;
+
+import java.time.Instant;
+
+import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.descriptors.Type;
+
+/**
+ * Adapter to convert {@link Instant} objects.
+ *
+ * <p>
+ * To allow backwards compatibility, this converter uses the same names as the serialization embedded in the
+ * {@link WrappedMessage}.
+ * </p>
+ */
+@ProtoAdapter(Instant.class)
+public class InstantAdapter {
+
+   @ProtoFactory
+   Instant create(Long seconds, Integer nanos) {
+      return Instant.ofEpochSecond(seconds, nanos);
+   }
+
+   @ProtoField(number = WrappedMessage.WRAPPED_INSTANT_SECONDS, type = Type.INT64, name = "_value")
+   Long getSeconds(Instant instant) {
+      return instant.getEpochSecond();
+   }
+
+   @ProtoField(number = WrappedMessage.WRAPPED_INSTANT_NANOS, type = Type.INT32, name = "wrappedInstantNanos")
+   Integer getNanos(Instant instant) {
+      return instant.getNano();
+   }
+}

--- a/types/src/test/java/org/infinispan/protostream/types/java/TypesMarshallingTest.java
+++ b/types/src/test/java/org/infinispan/protostream/types/java/TypesMarshallingTest.java
@@ -11,6 +11,7 @@ import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -67,7 +69,7 @@ public class TypesMarshallingTest {
             '}';
    }
 
-   @Parameterized.Parameters
+   @Parameterized.Parameters(name = "{0}")
    public static Object[][] marshallingMethods() {
       return Arrays.stream(MarshallingMethodType.values())
             .flatMap(t -> switch (t) {
@@ -82,6 +84,18 @@ public class TypesMarshallingTest {
             })
             .map(t -> new Object[]{t})
             .toArray(Object[][]::new);
+   }
+
+   @Test
+   public void testInstant() throws IOException {
+      testConfiguration.method.marshallAndUnmarshallTest(Instant.EPOCH, context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Instant.now(), context, false);
+   }
+
+   @Test
+   public void testDate() throws IOException {
+      testConfiguration.method.marshallAndUnmarshallTest(new Date(0), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new Date(), context, false);
    }
 
    @Test
@@ -320,6 +334,7 @@ public class TypesMarshallingTest {
 
             var json = ProtobufUtil.toCanonicalJSON(ctx, bytes);
             var jsonBytes = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
+            assertArrayEquals(bytes, jsonBytes);
 
             var copy = ProtobufUtil.fromWrappedByteArray(ctx, jsonBytes);
 


### PR DESCRIPTION
Backporting just the specific changes to Instant and Date from #411.