### PR TITLE
[#487] JSON serialization use only descriptor

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/impl/json/JsonHelper.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/JsonHelper.java
@@ -17,6 +17,8 @@ final class JsonHelper {
    static final String JSON_WHITESPACE = "   ";
 
    static boolean isContainerAdapter(ImmutableSerializationContext ctx, GenericDescriptor descriptor) {
-      return descriptor != null && ctx.getMarshaller(descriptor.getFullName()) instanceof ElementContainerAdapter<?>;
+      return descriptor != null
+            && ctx.canMarshall(descriptor.getFullName())
+            && ctx.getMarshaller(descriptor.getFullName()) instanceof ElementContainerAdapter<?>;
    }
 }

--- a/core/src/main/java/org/infinispan/protostream/impl/json/ObjectJsonWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/ObjectJsonWriter.java
@@ -62,14 +62,16 @@ class ObjectJsonWriter extends BaseJsonWriter {
       }
 
       // This means it is missing the comma, the field name, and then it can start the nested object.
+      boolean written = false;
       if (JsonToken.followedByComma(lastToken())) {
          pushToken(JsonToken.COMMA);
          pushToken(JsonTokenWriter.string(fieldDescriptor.getName()));
          pushToken(JsonToken.COLON);
+         written = true;
       }
 
       pushToken(JsonToken.LEFT_BRACE);
-      if (complexObject) {
+      if (complexObject && !written) {
          writeType(fieldDescriptor);
       }
    }

--- a/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
@@ -547,4 +547,32 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
 
       assertEquals(user, userResult);
    }
+
+   @Test
+   public void testJsonSerializationWithoutMarshaller() throws Exception {
+      SerializationContext ctx = ProtobufUtil.newSerializationContext();
+      final String protoDefinition =
+            """
+                  syntax = "proto2";
+                  message Person {
+                     optional string _type = 1;
+                     optional string name = 2;
+
+                     message Address {
+                       optional string _type = 1;
+                       optional string street = 2;
+                       optional string city = 3;
+                       optional string zip = 4;
+                     }
+
+                     optional Address address = 3;
+                  }""";
+      ctx.registerProtoFiles(FileDescriptorSource.fromString("person_definition.proto", protoDefinition));
+
+      String json = "{\"_type\":\"Person\", \"name\":\"joe\", \"address\":{\"_type\":\"Person.Address\", \"street\":\"\", \"city\":\"London\", \"zip\":\"0\"}}";
+      byte[] protobuf = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
+      String converted = ProtobufUtil.toCanonicalJSON(ctx, protobuf);
+      assertValid(converted);
+      assertEquals(json.replaceAll("[\\s\\n]+", ""), converted);
+   }
 }


### PR DESCRIPTION
* Do not require a marshaller to be registered.

Closes #487.