### PR TITLE
Add Schema created by String content

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/GeneratedSchema.java
+++ b/core/src/main/java/org/infinispan/protostream/GeneratedSchema.java
@@ -1,5 +1,7 @@
 package org.infinispan.protostream;
 
+import org.infinispan.protostream.schema.Schema;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
@@ -14,7 +16,17 @@ import java.io.UncheckedIOException;
  * @author anistor@redhat.com
  * @since 4.3.4
  */
-public interface GeneratedSchema extends SerializationContextInitializer {
+public interface GeneratedSchema extends SerializationContextInitializer, Schema {
+
+   @Override
+   default String getName() {
+      return getProtoFileName();
+   }
+
+   @Override
+   default String getContent() {
+      return getProtoFile();
+   }
 
    /**
     * Returns the name of the proto file. The name is allowed to contain slashes so it can look like an absolute

--- a/core/src/main/java/org/infinispan/protostream/schema/Schema.java
+++ b/core/src/main/java/org/infinispan/protostream/schema/Schema.java
@@ -1,7 +1,5 @@
 package org.infinispan.protostream.schema;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -9,154 +7,114 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @since 5.0
+ * Interface that represents a Schema
+ * Refers to programmatic schemas {@link Schema.Builder} and {@link org.infinispan.protostream.GeneratedSchema}
  */
-public class Schema {
-   private final Syntax syntax;
-   private final String name;
-   private final String packageName;
-   private final List<Enum> enums;
-   private final List<Message> messages;
-   private final Map<String, Object> options;
-   private final List<String> comments;
-   private final List<String> dependencies;
-   private final List<String> publicDependencies;
+public interface Schema {
 
-   private Schema(Builder builder) {
-      this.syntax = builder.syntax;
-      this.dependencies = List.copyOf(builder.dependencies);
-      this.publicDependencies = List.copyOf(builder.publicDependencies);
-      this.name = builder.name;
-      this.packageName = builder.packageName;
-      this.options = Map.copyOf(builder.options);
-      this.enums = builder.enums.values().stream().map(Enum.Builder::create).toList();
-      this.messages = builder.messages.values().stream().map(Message.Builder::create).toList();
-      this.comments = List.copyOf(builder.comments);
-   }
+    /**
+     * Gets the name of the schema
+     * @return the schema name
+     */
+    String getName();
 
-   public Syntax getSyntax() {
-      return syntax;
-   }
+    /**
+     * Gets the content of the schema
+     * @return the content
+     */
+    String getContent();
 
-   public String getName() {
-      return name;
-   }
+    /**
+     * Gets the content of the schema
+     *
+     * Use {@link Schema#getContent()}
+     * @deprecated
+     */
+    @Deprecated
+    String toString();
 
-   public String getPackageName() {
-      return packageName;
-   }
 
-   public List<Enum> getEnums() {
-      return enums;
-   }
+    static Schema buildFromStringContent(String schemaName, String schemaContent) {
+        return new SchemaByString(schemaName, schemaContent);
+    }
 
-   public List<Message> getMessages() {
-      return messages;
-   }
+    class Builder implements CommentContainer<Builder>, MessageContainer, OptionContainer<Builder>, EnumContainer {
+        Syntax syntax = Syntax.PROTO3;
+        final String name;
+        String packageName;
+        final java.util.Map<String, Enum.Builder> enums = new HashMap<>();
+        final java.util.Map<String, Message.Builder> messages = new HashMap<>();
+        final Map<String, Object> options = new HashMap<>();
+        final List<String> comments = new ArrayList<>();
+        final List<String> dependencies = new ArrayList<>();
+        final List<String> publicDependencies = new ArrayList<>();
 
-   public List<String> getComments() {
-      return comments;
-   }
+        public Builder(String name) {
+            this.name = name;
+        }
 
-   public List<String> getDependencies() {
-      return dependencies;
-   }
+        public Builder syntax(Syntax syntax) {
+            this.syntax = syntax;
+            return this;
+        }
 
-   public List<String> getPublicDependencies() {
-      return publicDependencies;
-   }
+        public Builder addImport(String i) {
+            dependencies.add(i);
+            return this;
+        }
 
-   public Map<String, Object> getOptions() {
-      return options;
-   }
+        public Builder addPublicImport(String i) {
+            publicDependencies.add(i);
+            return this;
+        }
 
-   public String toString() {
-      try {
-         StringWriter w = new StringWriter();
-         new SchemaWriter().write(w, this);
-         return w.toString();
-      } catch (IOException e) {
-         throw new RuntimeException(e);
-      }
-   }
+        public Builder packageName(String packageName) {
+            this.packageName = packageName;
+            return this;
+        }
 
-   public static class Builder implements CommentContainer<Builder>, MessageContainer, OptionContainer<Builder>, EnumContainer {
-      private Syntax syntax = Syntax.PROTO3;
-      private final String name;
-      private String packageName;
-      private final Map<String, Enum.Builder> enums = new HashMap<>();
-      private final Map<String, Message.Builder> messages = new HashMap<>();
-      private final Map<String, Object> options = new HashMap<>();
-      private final List<String> comments = new ArrayList<>();
-      private final List<String> dependencies = new ArrayList<>();
-      private final List<String> publicDependencies = new ArrayList<>();
+        @Override
+        public Builder addOption(String name, Object value) {
+            options.put(name, value);
+            return this;
+        }
 
-      public Builder(String name) {
-         this.name = name;
-      }
+        @Override
+        public Enum.Builder addEnum(String name) {
+            checkDuplicate(name);
+            Enum.Builder e = new Enum.Builder(this, name);
+            enums.put(name, e);
+            return e;
+        }
 
-      public Builder syntax(Syntax syntax) {
-         this.syntax = syntax;
-         return this;
-      }
+        @Override
+        public Message.Builder addMessage(String name) {
+            checkDuplicate(name);
+            Message.Builder message = new Message.Builder(this, name);
+            messages.put(name, message);
+            return message;
+        }
 
-      public Builder addImport(String i) {
-         dependencies.add(i);
-         return this;
-      }
+        @Override
+        public Builder addComment(String comment) {
+            comments.add(comment.trim());
+            return this;
+        }
 
-      public Builder addPublicImport(String i) {
-         publicDependencies.add(i);
-         return this;
-      }
+        @Override
+        public Schema build() {
+            return new SchemaByBuilder(this);
+        }
 
-      public Builder packageName(String packageName) {
-         this.packageName = packageName;
-         return this;
-      }
+        @Override
+        public String getFullName() {
+            return Objects.requireNonNullElse(packageName, "");
+        }
 
-      @Override
-      public Builder addOption(String name, Object value) {
-         options.put(name, value);
-         return this;
-      }
-
-      @Override
-      public Enum.Builder addEnum(String name) {
-         checkDuplicate(name);
-         Enum.Builder e = new Enum.Builder(this, name);
-         enums.put(name, e);
-         return e;
-      }
-
-      @Override
-      public Message.Builder addMessage(String name) {
-         checkDuplicate(name);
-         Message.Builder message = new Message.Builder(this, name);
-         messages.put(name, message);
-         return message;
-      }
-
-      @Override
-      public Builder addComment(String comment) {
-         comments.add(comment.trim());
-         return this;
-      }
-
-      @Override
-      public Schema build() {
-         return new Schema(this);
-      }
-
-      @Override
-      public String getFullName() {
-         return Objects.requireNonNullElse(packageName, "");
-      }
-
-      private void checkDuplicate(String name) {
-         if (messages.containsKey(name) || enums.containsKey(name)) {
-            throw new IllegalArgumentException("Duplicate name " + name);
-         }
-      }
-   }
+        private void checkDuplicate(String name) {
+            if (messages.containsKey(name) || enums.containsKey(name)) {
+                throw new IllegalArgumentException("Duplicate name " + name);
+            }
+        }
+    }
 }

--- a/core/src/main/java/org/infinispan/protostream/schema/SchemaByBuilder.java
+++ b/core/src/main/java/org/infinispan/protostream/schema/SchemaByBuilder.java
@@ -1,0 +1,85 @@
+package org.infinispan.protostream.schema;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @since 5.0
+ */
+class SchemaByBuilder implements Schema {
+   private final Syntax syntax;
+   private final String name;
+   private final String packageName;
+   private final List<Enum> enums;
+   private final List<Message> messages;
+   private final Map<String, Object> options;
+   private final List<String> comments;
+   private final List<String> dependencies;
+   private final List<String> publicDependencies;
+
+   SchemaByBuilder(Builder builder) {
+      this.syntax = builder.syntax;
+      this.dependencies = List.copyOf(builder.dependencies);
+      this.publicDependencies = List.copyOf(builder.publicDependencies);
+      this.name = builder.name;
+      this.packageName = builder.packageName;
+      this.options = Map.copyOf(builder.options);
+      this.enums = builder.enums.values().stream().map(Enum.Builder::create).toList();
+      this.messages = builder.messages.values().stream().map(Message.Builder::create).toList();
+      this.comments = List.copyOf(builder.comments);
+   }
+
+   public Syntax getSyntax() {
+      return syntax;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   @Override
+   public String getContent() {
+      return toString();
+   }
+
+   public String getPackageName() {
+      return packageName;
+   }
+
+   public List<Enum> getEnums() {
+      return enums;
+   }
+
+   public List<Message> getMessages() {
+      return messages;
+   }
+
+   public List<String> getComments() {
+      return comments;
+   }
+
+   public List<String> getDependencies() {
+      return dependencies;
+   }
+
+   public List<String> getPublicDependencies() {
+      return publicDependencies;
+   }
+
+   public Map<String, Object> getOptions() {
+      return options;
+   }
+
+   @Override
+   public String toString() {
+      try {
+         StringWriter w = new StringWriter();
+         new SchemaWriter().write(w, this);
+         return w.toString();
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/protostream/schema/SchemaByString.java
+++ b/core/src/main/java/org/infinispan/protostream/schema/SchemaByString.java
@@ -1,0 +1,29 @@
+package org.infinispan.protostream.schema;
+
+/**
+ * @since 6.0
+ */
+class SchemaByString implements Schema {
+   String fileName;
+   String fileContent;
+
+   SchemaByString(String fileName, String fileContent) {
+       this.fileName = fileName;
+       this.fileContent = fileContent;
+   }
+
+   @Override
+   public String getName() {
+      return fileName;
+   }
+
+   @Override
+   public String toString() {
+      return fileContent;
+   }
+
+   @Override
+   public String getContent() {
+      return fileContent;
+   }
+}

--- a/core/src/main/java/org/infinispan/protostream/schema/SchemaWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/schema/SchemaWriter.java
@@ -25,6 +25,18 @@ class SchemaWriter {
    }
 
    public void write(Writer w, Schema s) throws IOException {
+      if (s instanceof SchemaByBuilder sbb) {
+         write(w, sbb);
+         return;
+      }
+      if (s instanceof SchemaByString sbs) {
+         w.write(sbs.getContent());
+      }
+
+      throw new IllegalArgumentException("Unknown schema type: " + s);
+   }
+
+   private void write(Writer w, SchemaByBuilder s) throws IOException {
       w.write("syntax = \"");
       w.write(s.getSyntax().toString());
       w.write("\";\n");

--- a/core/src/test/java/org/infinispan/protostream/schema/ProtoBufSchemaTest.java
+++ b/core/src/test/java/org/infinispan/protostream/schema/ProtoBufSchemaTest.java
@@ -8,6 +8,8 @@ import org.infinispan.protostream.impl.Log;
 import org.infinispan.protostream.impl.parser.ProtostreamProtoParser;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ProtoBufSchemaTest {
    private static final Log log = Log.LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
@@ -87,6 +89,14 @@ public class ProtoBufSchemaTest {
                .addReserved("dont_wanna_say")
             .build();
       validateParsing(schema);
+   }
+
+   @Test
+   public void createByContentTest() {
+      Schema schema = Schema.buildFromStringContent("schema1", "contentschema");
+      assertThat(schema).isNotNull();
+      assertThat(schema.getName()).isEqualTo("schema1");
+      assertThat(schema.toString()).isEqualTo("contentschema");
    }
 
    private static void validateParsing(Schema schema) {


### PR DESCRIPTION
We use in many cases "string" "string" for our tests and more (since we were using the put api most of the time directly in the internal cache in Infinispan.

The idea is to be able to do:

```java
private static final String SCHEMA_NAME = "my-schema.proto";
Schema goodSchema = Schema.buildFromStringContent(SCHEMA_NAME, ResourceUtils.getResourceAsString(getClass(), "/proto/ciao.proto"));
Schema wrongSchema = Schema.buildFromStringContent(SCHEMA_NAME, ResourceUtils.getResourceAsString(getClass(), "/proto/ciao-wrong.proto"));

remoteCacheManager.administration().schemas().createOrUpdate(goodSchema);
///
remoteCacheManager.administration().schemas().createOrUpdate(wrongSchema);
```

Also GeneratedSchema to be Schema helps 