### PR TITLE
[#496] JSON do not allow restricted field names

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/impl/json/ObjectJsonWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/ObjectJsonWriter.java
@@ -62,16 +62,14 @@ class ObjectJsonWriter extends BaseJsonWriter {
       }
 
       // This means it is missing the comma, the field name, and then it can start the nested object.
-      boolean written = false;
       if (JsonToken.followedByComma(lastToken())) {
          pushToken(JsonToken.COMMA);
          pushToken(JsonTokenWriter.string(fieldDescriptor.getName()));
          pushToken(JsonToken.COLON);
-         written = true;
       }
 
       pushToken(JsonToken.LEFT_BRACE);
-      if (complexObject && !written) {
+      if (complexObject) {
          writeType(fieldDescriptor);
       }
    }


### PR DESCRIPTION
* JSON conversion do not allow conversion of entities using fields with the reserved names _type and _value.

Running `./mvnw clean verify`:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ProtoStream 6.0.0-SNAPSHOT:
[INFO] 
[INFO] ProtoStream - parent ............................... SUCCESS [  1.098 s]
[INFO] ProtoStream - core ................................. SUCCESS [  6.596 s]
[INFO] ProtoStream - annotation processor ................. SUCCESS [  2.445 s]
[INFO] ProtoStream - builtin types ........................ SUCCESS [  1.845 s]
[INFO] ProtoStream - integration tests .................... SUCCESS [  3.173 s]
[INFO] ProtoStream - backwards compatibility maven plugin . SUCCESS [  0.624 s]
[INFO] ProtoStream ........................................ SUCCESS [  0.353 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16.357 s
[INFO] Finished at: 2025-07-30T11:19:07-03:00
[INFO] ------------------------------------------------------------------------
```

Closes #496.