### PR TITLE
[#538] InputStream based unmarshalling via ProtobufUtil is quite slow

### DIFF
--- a/core/src/test/java/org/infinispan/protostream/impl/TagWriterImplTest.java
+++ b/core/src/test/java/org/infinispan/protostream/impl/TagWriterImplTest.java
@@ -106,8 +106,8 @@ public class TagWriterImplTest {
          }
 
          @Override
-         public TagReader newReader(SerializationContext ctx) {
-            return TagReaderImpl.newInstance(ctx, new ByteArrayInputStream(baos.toByteArray()));
+         public TagReader newReader(SerializationContext ctx) throws IOException {
+            return TagReaderImpl.newInstance(ctx, new ByteArrayInputStream(baos.toByteArray()), baos.size());
          }
       });
    }
@@ -122,7 +122,7 @@ public class TagWriterImplTest {
             }
 
             @Override
-            public TagReader newReader(SerializationContext ctx) {
+            public TagReader newReader(SerializationContext ctx) throws IOException {
                return TagReaderImpl.newInstance(ctx, new ByteArrayInputStream(out.toByteArray()));
             }
          });


### PR DESCRIPTION
* Eagerly unmarshall instead of creating ByteBuffer if possible

Fixes #538 