### PR TITLE
[#514] Add map adapters

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
@@ -41,6 +41,8 @@ import org.infinispan.protostream.containers.IndexedElementContainer;
 import org.infinispan.protostream.containers.IndexedElementContainerAdapter;
 import org.infinispan.protostream.containers.IterableElementContainer;
 import org.infinispan.protostream.containers.IterableElementContainerAdapter;
+import org.infinispan.protostream.containers.MapElementContainer;
+import org.infinispan.protostream.containers.MapElementContainerAdapter;
 import org.infinispan.protostream.descriptors.JavaType;
 import org.infinispan.protostream.descriptors.Type;
 import org.infinispan.protostream.impl.Log;
@@ -70,6 +72,8 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
 
    private final boolean isIterableContainer;
 
+   private final boolean isMapContainer;
+
    private final boolean isOrderedMarshallable;
 
    private XExecutable factory;
@@ -90,6 +94,7 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
       this.isAdapter = javaClass != annotatedClass;
       this.isIndexedContainer = annotatedClass.isAssignableTo(isAdapter ? IndexedElementContainerAdapter.class : IndexedElementContainer.class);
       this.isIterableContainer = annotatedClass.isAssignableTo(isAdapter ? IterableElementContainerAdapter.class : IterableElementContainer.class);
+      this.isMapContainer = annotatedClass.isAssignableTo(isAdapter ? MapElementContainerAdapter.class : MapElementContainer.class);
       this.isOrderedMarshallable = protoSchemaGenerator.orderedMarshaller();
 
       checkInstantiability();
@@ -125,8 +130,12 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
       return isIterableContainer;
    }
 
+   public boolean isMapContainer() {
+      return isMapContainer;
+   }
+
    public boolean isContainer() {
-      return isIterableContainer || isIndexedContainer;
+      return isIterableContainer || isIndexedContainer || isMapContainer;
    }
 
    public boolean isOrderedMarshallable() {

--- a/core/src/main/java/org/infinispan/protostream/containers/MapElementContainer.java
+++ b/core/src/main/java/org/infinispan/protostream/containers/MapElementContainer.java
@@ -1,0 +1,11 @@
+package org.infinispan.protostream.containers;
+
+import java.util.Map;
+
+/**
+ * Container adapter interface for {@link Map} implementations.
+ *
+ * @author José Bolina
+ * @since 6.0
+ */
+public interface MapElementContainer<K, V> extends IterableElementContainer<Map.Entry<K, V>> { }

--- a/core/src/main/java/org/infinispan/protostream/containers/MapElementContainerAdapter.java
+++ b/core/src/main/java/org/infinispan/protostream/containers/MapElementContainerAdapter.java
@@ -1,0 +1,17 @@
+package org.infinispan.protostream.containers;
+
+import java.util.Map;
+
+/**
+ * Container adapter interface for {@link Map} implementations.
+ *
+ * @author José Bolina
+ * @since 6.0
+ */
+public interface MapElementContainerAdapter<K, V, M extends Map<K, V>> extends IterableElementContainerAdapter<M, Map.Entry<K, V>> {
+
+   @Override
+   default void appendElement(M container, Map.Entry<K, V> element) {
+      container.put(element.getKey(), element.getValue());
+   }
+}

--- a/core/src/main/java/org/infinispan/protostream/impl/json/ContainerObjectWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/ContainerObjectWriter.java
@@ -29,6 +29,7 @@ import org.infinispan.protostream.descriptors.GenericDescriptor;
 final class ContainerObjectWriter extends BaseJsonWriter {
 
    private int containerFields = 1;
+   private boolean writtenElements = false;
 
    ContainerObjectWriter(ImmutableSerializationContext ctx, List<JsonTokenWriter> ast, FieldDescriptor descriptor) {
       super(ctx, ast, descriptor);
@@ -99,6 +100,7 @@ final class ContainerObjectWriter extends BaseJsonWriter {
             GenericDescriptor descriptor = ctx.getDescriptorByTypeId(WrappedMessage.PROTOBUF_TYPE_ID);
             TagHandler delegate = new RootJsonWriter(ctx, ast);
             delegate.onStart(descriptor);
+            writtenElements |= lastToken() == JsonToken.LEFT_BRACKET;
             delegate.onTag(fieldNumber, fieldDescriptor, tagValue);
             delegate.onEnd();
          }
@@ -111,6 +113,7 @@ final class ContainerObjectWriter extends BaseJsonWriter {
    }
 
    private void writePrimitiveContainer(FieldDescriptor fieldDescriptor, Object tagValue) {
+      writtenElements = true;
       pushToken(JsonToken.LEFT_BRACE);
       pushToken(JsonTokenWriter.string(fieldDescriptor.getTypeName()));
       pushToken(JsonToken.COLON);
@@ -120,6 +123,7 @@ final class ContainerObjectWriter extends BaseJsonWriter {
 
    @Override
    public void onEnd() {
-      pushToken(JsonToken.RIGHT_BRACKET);
+      if (writtenElements)
+         pushToken(JsonToken.RIGHT_BRACKET);
    }
 }

--- a/processor/src/main/java/org/infinispan/protostream/processor/MarshallerSourceCodeGenerator.java
+++ b/processor/src/main/java/org/infinispan/protostream/processor/MarshallerSourceCodeGenerator.java
@@ -9,6 +9,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,6 +32,7 @@ import org.infinispan.protostream.annotations.impl.types.XClass;
 import org.infinispan.protostream.annotations.impl.types.XTypeFactory;
 import org.infinispan.protostream.containers.IndexedElementContainerAdapter;
 import org.infinispan.protostream.containers.IterableElementContainerAdapter;
+import org.infinispan.protostream.containers.MapElementContainerAdapter;
 import org.infinispan.protostream.impl.Log;
 import org.infinispan.protostream.processor.types.HasModelElement;
 
@@ -184,6 +186,13 @@ final class MarshallerSourceCodeGenerator extends AbstractMarshallerCodeGenerato
       if (pmtm.isIndexedContainer()) {
          elementType = pmtm.getAnnotatedClass().getGenericInterfaceParameterTypes(IndexedElementContainerAdapter.class)[1];
          iw.printf(", %s<%s, %s>", IndexedElementContainerAdapter.class.getName(), pmtm.getJavaClassName(), elementType);
+      } else if (pmtm.isMapContainer()) {
+         String[] types = pmtm.getAnnotatedClass().getGenericInterfaceParameterTypes(MapElementContainerAdapter.class);
+         String map = pmtm.getJavaClassName();
+         String key = types[0];
+         String value = types[1];
+         elementType = Map.Entry.class.getCanonicalName();
+         iw.printf(", %s<%s, %s, %s<%s, %s>>", MapElementContainerAdapter.class.getName(), key, value, map, key, value);
       } else if (pmtm.isIterableContainer()) {
          elementType = pmtm.getAnnotatedClass().getGenericInterfaceParameterTypes(IterableElementContainerAdapter.class)[1];
          iw.printf(", %s<%s, %s>", IterableElementContainerAdapter.class.getName(), pmtm.getJavaClassName(), elementType);

--- a/types/src/main/java/org/infinispan/protostream/types/java/CommonContainerTypes.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/CommonContainerTypes.java
@@ -22,6 +22,8 @@ import org.infinispan.protostream.types.java.collections.HashSetAdapter;
 import org.infinispan.protostream.types.java.collections.LinkedHashSetAdapter;
 import org.infinispan.protostream.types.java.collections.LinkedListAdapter;
 import org.infinispan.protostream.types.java.collections.TreeSetAdapter;
+import org.infinispan.protostream.types.java.util.MapAdapters;
+import org.infinispan.protostream.types.java.util.MapEntryAdapter;
 
 /**
  * Support for marshalling various {@link java.util.Collection} implementations and array or primitives.
@@ -56,7 +58,21 @@ import org.infinispan.protostream.types.java.collections.TreeSetAdapter;
             BoxedFloatArrayAdapter.class,
             BoxedDoubleArrayAdapter.class,
             StringArrayAdapter.class,
-            ObjectArrayAdapter.class
+            ObjectArrayAdapter.class,
+
+            // maps
+            MapEntryAdapter.class,
+            MapAdapters.HashMapAdapter.class,
+            MapAdapters.ConcurrentHashMapAdapter.class,
+            MapAdapters.LinkedHashMapAdapter.class,
+            MapAdapters.TreeMapAdapter.class,
+            MapAdapters.WeakHashMapAdapter.class,
+            MapAdapters.IdentityHashMapAdapter.class,
+            MapAdapters.ConcurrentSkipListMapAdapter.class,
+            MapAdapters.HashtableAdapter.class,
+            MapAdapters.PropertiesAdapter.class,
+            MapAdapters.CollectionsEmptyMap.class,
+            MapAdapters.CollectionSingletonMap.class,
       }
 )
 public interface CommonContainerTypes extends GeneratedSchema {

--- a/types/src/main/java/org/infinispan/protostream/types/java/util/AbstractMapAdapter.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/util/AbstractMapAdapter.java
@@ -1,0 +1,94 @@
+package org.infinispan.protostream.types.java.util;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.infinispan.protostream.containers.MapElementContainerAdapter;
+
+/**
+ * Base adapter for {@link Map} implementations.
+ *
+ * @author José Bolina
+ * @since 6.0
+ */
+public abstract class AbstractMapAdapter<K, V, M extends Map<K, V>> implements MapElementContainerAdapter<K, V, M> {
+
+   abstract public M create(int size);
+
+   @Override
+   public Iterator<Map.Entry<K, V>> getElements(M container) {
+      return AbstractMapAdapter.toIterator(container);
+   }
+
+   public static <K, V> MapEntryWrapper<K, V> entry(Map.Entry<K, V> entry) {
+      if (entry instanceof AbstractMapAdapter.MapEntryWrapper) {
+         return (AbstractMapAdapter.MapEntryWrapper<K, V>) entry;
+      }
+      return new MapEntryWrapper<>(entry);
+   }
+
+   static <K, V> Iterator<Map.Entry<K, V>> toIterator(Map<K, V> map) {
+      Iterator<Map.Entry<K, V>> delegate = map.entrySet().iterator();
+      return new Iterator<>() {
+
+         @Override
+         public boolean hasNext() {
+            return delegate.hasNext();
+         }
+
+         @Override
+         public Map.Entry<K, V> next() {
+            Map.Entry<K, V> entry = delegate.next();
+            // Wrap entries in our MapEntryWrapper to provide a consistent serializable type
+            return MapEntryWrapper.create(entry);
+         }
+      };
+   }
+
+   @Override
+   public final int getNumElements(M container) {
+      return container.size();
+   }
+
+   /**
+    * Wrapper for {@link Map.Entry} instances.
+    * <p>
+    * This wrapper is necessary because there are several implementations of the {@link Map.Entry} interface
+    * across different map types (e.g., HashMap.Node, TreeMap.Entry, etc.). Instead of creating a separate
+    * ProtoStream adapter for each implementation, we wrap all entries in this single, consistent type that
+    * can be serialized uniformly.
+    *
+    * @param <K> the type of the entry key
+    * @param <V> the type of the entry value
+    */
+   public static class MapEntryWrapper<K, V> implements Map.Entry<K, V> {
+      private final Map.Entry<K, V> entry;
+
+      private MapEntryWrapper(Map.Entry<K, V> entry) {
+         this.entry = entry;
+      }
+
+      public static <K, V> Map.Entry<K, V> create(K key, V value) {
+         return new MapEntryWrapper<>(Map.entry(key, value));
+      }
+
+      public static <K, V> Map.Entry<K, V> create(Map.Entry<K, V> entry) {
+         return new MapEntryWrapper<>(entry);
+      }
+
+      @Override
+      public K getKey() {
+         return entry.getKey();
+      }
+
+      @Override
+      public V getValue() {
+         return entry.getValue();
+      }
+
+      @Override
+      public V setValue(V v) {
+         return entry.setValue(v);
+      }
+   }
+}

--- a/types/src/main/java/org/infinispan/protostream/types/java/util/MapAdapters.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/util/MapAdapters.java
@@ -1,0 +1,225 @@
+package org.infinispan.protostream.types.java.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+/**
+ * ProtoStream adapters for various {@link Map} implementations.
+ *
+ * @author José Bolina
+ * @since 6.0
+ */
+public final class MapAdapters {
+
+   /**
+    * Adapter for {@link HashMap} and immutable Map implementations.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(
+         value = Map.class,
+         subClassNames = {
+               "java.util.HashMap",
+               "java.util.ImmutableCollections$Map1",
+               "java.util.ImmutableCollections$MapN",
+         }
+   )
+   public static class HashMapAdapter<K, V> extends AbstractMapAdapter<K, V, Map<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public Map<K, V> create(int size) {
+         return new HashMap<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link ConcurrentHashMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(ConcurrentHashMap.class)
+   public static class ConcurrentHashMapAdapter<K, V> extends AbstractMapAdapter<K, V, ConcurrentHashMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public ConcurrentHashMap<K, V> create(int size) {
+         return new ConcurrentHashMap<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link LinkedHashMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(LinkedHashMap.class)
+   public static class LinkedHashMapAdapter<K, V> extends AbstractMapAdapter<K, V, LinkedHashMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public LinkedHashMap<K, V> create(int size) {
+         return new LinkedHashMap<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link TreeMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(TreeMap.class)
+   public static class TreeMapAdapter<K, V> extends AbstractMapAdapter<K, V, TreeMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public TreeMap<K, V> create(int ignore) {
+         return new TreeMap<>();
+      }
+   }
+
+   /**
+    * Adapter for {@link WeakHashMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(WeakHashMap.class)
+   public static class WeakHashMapAdapter<K, V> extends AbstractMapAdapter<K, V, WeakHashMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public WeakHashMap<K, V> create(int size) {
+         return new WeakHashMap<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link IdentityHashMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(IdentityHashMap.class)
+   public static class IdentityHashMapAdapter<K, V> extends AbstractMapAdapter<K, V, IdentityHashMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public IdentityHashMap<K, V> create(int size) {
+         return new IdentityHashMap<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link ConcurrentSkipListMap}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(ConcurrentSkipListMap.class)
+   public static class ConcurrentSkipListMapAdapter<K, V> extends AbstractMapAdapter<K, V, ConcurrentSkipListMap<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public ConcurrentSkipListMap<K, V> create(int ignore) {
+         return new ConcurrentSkipListMap<>();
+      }
+   }
+
+   /**
+    * Adapter for {@link Hashtable}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(Hashtable.class)
+   public static class HashtableAdapter<K, V> extends AbstractMapAdapter<K, V, Hashtable<K, V>> {
+
+      @ProtoFactory
+      @Override
+      public Hashtable<K, V> create(int size) {
+         return new Hashtable<>(size);
+      }
+   }
+
+   /**
+    * Adapter for {@link Properties}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(
+         value = Map.class,
+         subClassNames = "java.util.Properties"
+   )
+   public static class PropertiesAdapter extends AbstractMapAdapter<Object, Object, Map<Object, Object>> {
+
+      @ProtoFactory
+      @Override
+      public Map<Object, Object> create(int ignore) {
+         return new Properties();
+      }
+   }
+
+   /**
+    * Adapter for {@link Collections#emptyMap()}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(
+         value = Map.class,
+         subClassNames = {
+               "java.util.Collections$EmptyMap",
+         }
+   )
+   public static class CollectionsEmptyMap<K, V> {
+
+      @ProtoFactory
+      public Map<K, V> create() {
+         return Collections.emptyMap();
+      }
+   }
+
+   /**
+    * Adapter for {@link Collections#singletonMap(Object, Object)}.
+    *
+    * @author José Bolina
+    * @since 6.0
+    */
+   @ProtoAdapter(
+         value = Map.class,
+         subClassNames = "java.util.Collections$SingletonMap"
+   )
+   public static class CollectionSingletonMap<K, V> {
+
+      @ProtoFactory
+      public Map<K, V> create(AbstractMapAdapter.MapEntryWrapper<? extends K, ? extends V> entry) {
+         return Collections.singletonMap(entry.getKey(), entry.getValue());
+      }
+
+      @ProtoField(number = 1)
+      AbstractMapAdapter.MapEntryWrapper<K, V> getEntry(Map<K, V> map) {
+         Iterator<Map.Entry<K, V>> iterator = map.entrySet().iterator();
+         return AbstractMapAdapter.entry(iterator.next());
+      }
+   }
+}

--- a/types/src/main/java/org/infinispan/protostream/types/java/util/MapEntryAdapter.java
+++ b/types/src/main/java/org/infinispan/protostream/types/java/util/MapEntryAdapter.java
@@ -1,0 +1,34 @@
+package org.infinispan.protostream.types.java.util;
+
+import java.util.Map;
+
+import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+/**
+ * Adapter for {@link Map.Entry} wrapper used in map serialization.
+ *
+ * @author José Bolina
+ * @since 6.0
+ */
+@SuppressWarnings("rawtypes")
+@ProtoAdapter(AbstractMapAdapter.MapEntryWrapper.class)
+public class MapEntryAdapter {
+
+   @ProtoFactory
+   AbstractMapAdapter.MapEntryWrapper create(WrappedMessage key, WrappedMessage value) {
+      return (AbstractMapAdapter.MapEntryWrapper) AbstractMapAdapter.MapEntryWrapper.create(key.getValue(), value.getValue());
+   }
+
+   @ProtoField(number = 1)
+   WrappedMessage getKey(Map.Entry entry) {
+      return new WrappedMessage(entry.getKey());
+   }
+
+   @ProtoField(number = 2)
+   WrappedMessage getValue(Map.Entry entry) {
+      return new WrappedMessage(entry.getValue());
+   }
+}

--- a/types/src/test/java/org/infinispan/protostream/types/java/TypesMarshallingTest.java
+++ b/types/src/test/java/org/infinispan/protostream/types/java/TypesMarshallingTest.java
@@ -31,13 +31,20 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -139,6 +146,46 @@ public class TypesMarshallingTest {
             new HashMap<>()
       );
       testConfiguration.method.marshallAndUnmarshallTest(msg, context, false);
+   }
+
+   @Test
+   public void testManyMaps() throws IOException {
+      assumeTrue(testConfiguration.runTest);
+      testConfiguration.method.marshallAndUnmarshallTest(new HashMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new ConcurrentHashMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new LinkedHashMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new TreeMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new WeakHashMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new ConcurrentSkipListMap<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(new Hashtable<>(Map.of("key", "value")), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Collections.singletonMap("key", "value"), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Collections.emptyMap(), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Map.of(), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Map.of("k", "v"), context, false);
+      testConfiguration.method.marshallAndUnmarshallTest(Map.of("k", "v", "k1", "v1"), context, false);
+   }
+
+   @Test
+   public void testPropertiesMap() throws IOException {
+      assumeTrue(testConfiguration.runTest);
+      var props = new Properties();
+      props.setProperty("key1", "value1");
+      props.setProperty("key2", "value2");
+      testConfiguration.method.marshallAndUnmarshallTest(props, context, false);
+   }
+
+   @Test
+   public void testMapWithComplexTypes() throws IOException {
+      assumeTrue(testConfiguration.runTest);
+      var bookMap = new HashMap<String, Book>();
+      bookMap.put("book1", new Book("Title1", "Desc1", 2020));
+      bookMap.put("book2", new Book("Title2", "Desc2", 2021));
+      testConfiguration.method.marshallAndUnmarshallTest(bookMap, context, false);
+
+      var nestedMap = new HashMap<Integer, List<String>>();
+      nestedMap.put(1, List.of("a", "b", "c"));
+      nestedMap.put(2, List.of("d", "e", "f"));
+      testConfiguration.method.marshallAndUnmarshallTest(nestedMap, context, false);
    }
 
    @Test


### PR DESCRIPTION
* Include adapters for several Map implementations.
* Utilize dedicated adapters so they can return the concrete type as much as possible.
* Smaller fixes to code generation of maps and JSON parsing of container messages.

Close #514 