### PR TITLE
Fix copy-on-write resolution losing types when other files fail to resolve

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/FileDescriptor.java
@@ -239,6 +239,7 @@ public final class FileDescriptor {
          }
 
          status = Status.RESOLVED;
+         resolutionContext.flush();
          resolutionContext.handleSuccess(this);
       } catch (DescriptorParserException dpe) {
          resolutionContext.handleError(this, dpe);

--- a/core/src/main/java/org/infinispan/protostream/descriptors/ResolutionContext.java
+++ b/core/src/main/java/org/infinispan/protostream/descriptors/ResolutionContext.java
@@ -161,16 +161,11 @@ public class ResolutionContext {
       return v != null ? v : second.get(k);
    }
 
-   public Map<String, GenericDescriptor> getResolvedTypes() {
-      return globalTypes;
-   }
-
-   public Map<String, EnumValueDescriptor> getResolvedEnumValues() {
-      return enumValueDescriptors;
-   }
-
-   public Map<Integer, GenericDescriptor> getResolvedTypeIds() {
-      return typeIds;
+   void flush() {
+      allGlobalTypes.putAll(globalTypes);
+      allTypeIds.putAll(typeIds);
+      allEnumValueDescriptors.putAll(enumValueDescriptors);
+      clear();
    }
 
    void clear() {

--- a/core/src/main/java/org/infinispan/protostream/impl/SerializationContextImpl.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/SerializationContextImpl.java
@@ -2,7 +2,6 @@ package org.infinispan.protostream.impl;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -116,22 +115,14 @@ public final class SerializationContextImpl implements SerializationContext {
          // resolve imports and types for all files
          ResolutionContext resolutionContext = new ResolutionContext(
                source.getProgressCallback(),
-               // Utilized for imports resolution.
                fileDescriptors,
-               // Read-only view of snapshot for uniqueness checks.
-               Collections.unmodifiableMap(genericDescriptors),
+               genericDescriptors,
                typeIds,
-               Collections.unmodifiableMap(enumDescriptors));
+               enumDescriptors);
 
          try {
-            // Resolution will try to resolve the file but might throw.
-            // We should still include the files, even with failures, to the context.
-            // This allows to keep track of failed resolutions.
             resolutionContext.resolve();
          } finally {
-            genericDescriptors.putAll(resolutionContext.getResolvedTypes());
-            enumDescriptors.putAll(resolutionContext.getResolvedEnumValues());
-            typeIds.putAll(resolutionContext.getResolvedTypeIds());
             descriptors = new DescriptorSnapshot(fileDescriptors, genericDescriptors, enumDescriptors, typeIds);
          }
       } finally {

--- a/core/src/test/java/org/infinispan/protostream/impl/SerializationContextImplTest.java
+++ b/core/src/test/java/org/infinispan/protostream/impl/SerializationContextImplTest.java
@@ -413,6 +413,49 @@ public class SerializationContextImplTest {
       assertFalse(fileDescriptor.isResolved());
    }
 
+   @Test
+   public void testResolvedTypesPreservedWhenOtherFileFails() {
+      SerializationContext ctx = createContext();
+
+      String validFile = """
+            syntax = "proto3";
+            package test;
+            message A {
+               optional int32 f1 = 1;
+            }""";
+
+      String invalidFile = "import \"no_such_file.proto\";";
+
+      Map<String, DescriptorParserException> errors = new HashMap<>();
+      List<String> successful = new ArrayList<>();
+      FileDescriptorSource source = new FileDescriptorSource()
+            .addProtoFile("valid.proto", validFile)
+            .addProtoFile("invalid.proto", invalidFile)
+            .withProgressCallback(new FileDescriptorSource.ProgressCallback() {
+               @Override
+               public void handleError(String fileName, DescriptorParserException exception) {
+                  errors.put(fileName, exception);
+               }
+
+               @Override
+               public void handleSuccess(String fileName) {
+                  successful.add(fileName);
+               }
+            });
+      ctx.registerProtoFiles(source);
+
+      assertEquals(1, successful.size());
+      assertTrue(successful.contains("valid.proto"));
+      assertEquals(1, errors.size());
+      assertTrue(errors.containsKey("invalid.proto"));
+
+      Map<String, FileDescriptor> fileDescriptors = ctx.getFileDescriptors();
+      assertTrue(fileDescriptors.get("valid.proto").isResolved());
+      assertFalse(fileDescriptors.get("invalid.proto").isResolved());
+
+      assertNotNull(ctx.getGenericDescriptors().get("test.A"));
+   }
+
    /**
     * Test that files with syntax errors DO NOT get registered if there is no progress callback present.
     */


### PR DESCRIPTION
Fixes #679

## Summary

- Re-add per-file `flush()` in `FileDescriptor.resolveDependencies()` so successfully resolved types are committed to the global maps immediately, preventing a subsequent file's failure from wiping them via `clear()`
- Remove `Collections.unmodifiableMap()` wrappers in `SerializationContextImpl.registerProtoFiles()` so `flush()` can write directly to the local copy maps
- Remove redundant `putAll(getResolved*())` calls since `flush()` handles this
- Add reproducer test `testResolvedTypesPreservedWhenOtherFileFails`

## Context

PR #670 introduced copy-on-write snapshots for `SerializationContext` state but removed the per-file `resolutionContext.flush()` call from `FileDescriptor.resolveDependencies()`. Without it, types from all resolved files accumulate in `ResolutionContext`'s local maps. When a later file fails to resolve, the `finally` block calls `clear()`, wiping all accumulated types — including those from previously successful files.

This surfaces in Infinispan's `ProtobufResourceTest` where schemas are removed one-by-one (leaving dependants unresolved), then new schemas are registered. The unresolved dependants fail to re-resolve during `resolve()`, and `clear()` destroys the newly registered schema's types.

## Test plan

- [x] New test `testResolvedTypesPreservedWhenOtherFileFails` registers a valid and invalid file together, asserts the valid file's types survive
- [x] All existing `SerializationContextImplTest` tests pass