### PR TITLE
[#689] Downgrade empty @ProtoField warning to debug

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
+++ b/core/src/main/java/org/infinispan/protostream/annotations/impl/ProtoMessageTypeMetadata.java
@@ -252,9 +252,7 @@ public class ProtoMessageTypeMetadata extends ProtoTypeMetadata {
 
          discoverFields(annotatedClass, new HashSet<>(), fieldsByNumber, fieldsByName, oneofs);
          if (fieldsByNumber.isEmpty()) {
-            //todo avoid this warning in case where not necessary
-            // TODO [anistor] remove the "The class should be either annotated or it should have a custom marshaller" part after MessageMarshaller is removed in 5
-            log.warnf("Class %s does not have any @ProtoField annotated members. The class should be either annotated or it should have a custom marshaller.", getAnnotatedClassName());
+            log.debugf("Class %s does not have any @ProtoField annotated members.", getAnnotatedClassName());
          }
 
          // If we have a factory method / constructor, we must ensure its parameters match the declared fields.


### PR DESCRIPTION
## Summary

Classes included in a `@ProtoSchema` that have no `@ProtoField` annotated members (e.g. marker/singleton types) are valid protobuf messages with zero fields. The current WARN level log produces noisy build output in downstream projects like Infinispan.

This change:
* Downgrades the log level from WARN to DEBUG
* Removes the outdated TODO comments and the `MessageMarshaller` reference (removed in ProtoStream 5)

Resolves #689

Created with the assistance of an AI tool