### PR TITLE
[#697] Harden GitHub Actions with top-level permissions and SHA pinning

### DIFF
--- a/.github/workflows/add_infinispan_release_label_to_issues.yaml
+++ b/.github/workflows/add_infinispan_release_label_to_issues.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   add-release-label:
     if: ${{ github.event.pull_request.merged }}

--- a/.github/workflows/add_issues_to_major_project.yaml
+++ b/.github/workflows/add_issues_to_major_project.yaml
@@ -8,13 +8,16 @@ on:
       - opened
       # Triggers the workflow when a new issue is opened in the repository.
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
     # Specifies the environment where the job will run. In this case, it uses the latest Ubuntu runner.
 
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         # Uses the `actions/add-to-project` GitHub Action to add items to a GitHub project.
         # This action simplifies the process of adding issues or pull requests to a project board.
 

--- a/.github/workflows/dependabot_pull_request.yml
+++ b/.github/workflows/dependabot_pull_request.yml
@@ -10,6 +10,9 @@ on:
       - opened
       - reopened
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
@@ -19,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Approve PR for auto-merge
         run: gh pr merge --auto --rebase ${{ github.event.pull_request.number }}

--- a/.github/workflows/needs_rebase.yaml
+++ b/.github/workflows/needs_rebase.yaml
@@ -8,13 +8,17 @@ on:
     branches:
       - '*.0.x'
       - 'main'
+
+permissions:
+  contents: read
+
 jobs:
   triage:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@releases/2.x
+      - uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # releases/2.x
         with:
           dirtyLabel: "pr/needs rebase"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   jdk:
     name: JDK Build
@@ -16,10 +19,10 @@ jobs:
       matrix:
         jdk: [17, 21, 25-ea]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
@@ -29,7 +32,7 @@ jobs:
         run: ./mvnw -B clean install artifact:compare -Dmaven.test.failure.ignore=true -Dansi.strip=true
 
       - name: Test Logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success() || failure()
         with:
           name: ${{ matrix.jdk }}-test-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,21 @@ on:
         description: "Next version (blank = next micro SNAPSHOT)"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.resolve-versions.outputs.RELEASE_VERSION }}
       nextVersion: ${{ steps.resolve-versions.outputs.NEXT_VERSION }}
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.branch }}
           ssh-key: ${{ secrets.INFINISPAN_RELEASE_PRIVATE_KEY }}
@@ -74,7 +79,7 @@ jobs:
           git commit -a -m "Releasing ${{ steps.resolve-versions.outputs.RELEASE_VERSION }}" --no-verify
 
       - name: Set up Java for publishing to Sonatype Central
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -101,7 +106,7 @@ jobs:
           git commit -a -m "Next version ${{ steps.resolve-versions.outputs.NEXT_VERSION }}" --no-verify
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ inputs.branch }}
@@ -117,7 +122,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: GOSCHEN/http-status-code@v1.1.0
+      - uses: GOSCHEN/http-status-code@944938ed534b092b9f7e1e5c6b08c5d9bbc35162 # v1.1.0
         with:
           url: https://repo1.maven.org/maven2/org/infinispan/protostream/protostream/${{ needs.release.outputs.version }}/protostream-${{ needs.release.outputs.version }}.pom
           code: 200

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -4,22 +4,29 @@ on:
     workflows: ['Test']
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   report:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      actions: read
     strategy:
       matrix:
         jdk: [17, 21, 25-ea]
     steps:
       - name: Download Surefire Report Artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.jdk }}-test-results
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           path: ${{ matrix.jdk }}
 
-      - uses: rigazilla/action-surefire-report@summary
+      - uses: rigazilla/action-surefire-report@93b492377a7dde6a3f644cc18d4d74846cac71f3 # summary
         with:
           fail_on_test_failures: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,6 +38,9 @@ jobs:
             ${{ matrix.jdk }}/**/*-reports*/**/TEST-*.xml
   report-summary:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      statuses: write
     needs: report
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions` blocks to all 7 workflow files, defaulting to `contents: read` with elevated scopes only where needed
- Pin every external action reference to immutable 40-char commit SHAs with trailing version comments, preventing supply-chain attacks via mutable tag/branch references
- Dependabot will continue to update SHA pins as new versions are released

Fixes #697

Created with the assistance of an AI tool