### PR TITLE
[#706] Tighten GitHub Actions workflow permissions to least privilege

### DIFF
--- a/.github/workflows/add_issues_to_major_project.yaml
+++ b/.github/workflows/add_issues_to_major_project.yaml
@@ -8,8 +8,7 @@ on:
       - opened
       # Triggers the workflow when a new issue is opened in the repository.
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   add-to-project:

--- a/.github/workflows/ai_ide_config_notice.yml
+++ b/.github/workflows/ai_ide_config_notice.yml
@@ -28,6 +28,8 @@ on:
       - '**/AI.md'
       - '**/AI-*.md'
 
+permissions: {}
+
 jobs:
   notice:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
   published:
     needs: release
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: GOSCHEN/http-status-code@944938ed534b092b9f7e1e5c6b08c5d9bbc35162 # v1.1.0
         with:

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      statuses: write
     needs: report
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- Add top-level `permissions: {}` to `ai_ide_config_notice.yml` so new jobs default to no permissions
- Add `permissions: {}` to `release.yml` `published` job (only polls Maven Central, no GitHub API)
- Remove unused `statuses: write` from `test_report.yaml` `report-summary` job (only uses `checks: write`)
- Change `add_issues_to_major_project.yaml` top-level permissions to `{}` (uses PAT, not GITHUB_TOKEN)

Closes #706

Created with the assistance of an AI tool