### PR TITLE
[#738] Fix JSON serialization for nested maps and repeated fields

### DIFF
--- a/core/src/main/java/org/infinispan/protostream/impl/json/ArrayJsonWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/ArrayJsonWriter.java
@@ -68,12 +68,15 @@ final class ArrayJsonWriter extends BaseJsonWriter {
          done = false;
       } else {
          // Otherwise, we are starting a fresh list.
-         // We populate the property name if we're starting a list where it is still missing.
-         if (JsonToken.followedByComma(lastToken())) {
-            pushToken(JsonToken.COMMA);
-            pushToken(JsonTokenWriter.string(fieldDescriptor.getName()));
-            pushToken(JsonToken.COLON);
-         }
+          // We populate the property name if we're starting a list where it is still missing.
+          if (JsonToken.followedByComma(lastToken())) {
+             pushToken(JsonToken.COMMA);
+             pushToken(JsonTokenWriter.string(fieldDescriptor.getName()));
+             pushToken(JsonToken.COLON);
+          } else if (JsonToken.isOpen(lastToken())) {
+             pushToken(JsonTokenWriter.string(fieldDescriptor.getName()));
+             pushToken(JsonToken.COLON);
+          }
          pushToken(JsonToken.LEFT_BRACKET);
       }
 

--- a/core/src/main/java/org/infinispan/protostream/impl/json/MapJsonWriter.java
+++ b/core/src/main/java/org/infinispan/protostream/impl/json/MapJsonWriter.java
@@ -31,6 +31,10 @@ import org.infinispan.protostream.descriptors.FieldDescriptor;
 final class MapJsonWriter extends BaseJsonWriter {
 
    private FieldAwareTagHandler delegate;
+
+   // The descriptor of the value field of the current entry.
+   // It is not-null only while the value is a nested message being written by the delegate.
+   private FieldDescriptor valueField;
    private int lastField = 0;
    private boolean done;
 
@@ -62,15 +66,31 @@ final class MapJsonWriter extends BaseJsonWriter {
          return;
       }
 
+      if (delegate != null) {
+         // The value message is still open.
+         // Any nested structure starting now belongs to it (or to a structure it contains), delegate it.
+         delegate.onStartNested(fieldNumber, fieldDescriptor);
+         return;
+      }
+
       if (fieldNumber != MAP_VALUE_FIELD)
          throw new IllegalStateException("Maps only have nested objects for values");
 
+      valueField = fieldDescriptor;
       delegate = createDelegate(fieldNumber, fieldDescriptor);
       pushToken(JsonToken.LEFT_BRACE);
    }
 
    @Override
    public void onTag(int fieldNumber, FieldDescriptor fieldDescriptor, Object tagValue) {
+      if (delegate != null) {
+         // The value message is still open.
+         // This tag belongs to the value message (or to a structure it contains), delegate it.
+         delegate.onTag(fieldNumber, fieldDescriptor, tagValue);
+         lastField = delegate.field();
+         return;
+      }
+
       lastField = fieldNumber;
       if (fieldNumber == MAP_KEY_FIELD) {
          if (lastToken() == JsonToken.COLON)
@@ -78,12 +98,6 @@ final class MapJsonWriter extends BaseJsonWriter {
 
          pushToken(JsonTokenWriter.string(Objects.toString(tagValue)));
          pushToken(JsonToken.COLON);
-         return;
-      }
-
-      if (delegate != null) {
-         lastField = delegate.field();
-         delegate.onTag(fieldNumber, fieldDescriptor, tagValue);
          return;
       }
 
@@ -95,8 +109,14 @@ final class MapJsonWriter extends BaseJsonWriter {
    @Override
    public void onEndNested(int fieldNumber, FieldDescriptor fieldDescriptor) {
       if (delegate != null) {
+         // The value message is still open.
+         // This end belongs either to a structure inside the value message, or to the value message itself.
          delegate.onEndNested(fieldNumber, fieldDescriptor);
-         delegate = null;
+         if (fieldDescriptor == valueField) {
+            delegate = null;
+            valueField = null;
+            lastField = MAP_VALUE_FIELD;
+         }
          return;
       }
 

--- a/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
+++ b/core/src/test/java/org/infinispan/protostream/ProtobufUtilTest.java
@@ -988,8 +988,118 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
       assertThat(message).contains("Field number '2' has reserved name '_type'");
    }
 
-   @Test
-   public void testStructuredObject() throws IOException {
+    @Test
+    public void testMapWithNestedObjectValues() throws Exception {
+       SerializationContext ctx = ProtobufUtil.newSerializationContext();
+       final String protoDefinition = """
+          syntax = "proto2";
+          message RootAuthenticationSessionEntity {
+             optional string realmId = 1;
+             optional string id = 2;
+             optional int64 timestamp = 3;
+             map<string, AuthenticationSession> authenticationSessions = 4;
+          }
+          message AuthenticationSession {
+             enum Action {
+                AUTHENTICATE = 1;
+             }
+             enum ExecutionStatus {
+                CHALLENGED = 1;
+                ATTEMPTED = 2;
+                SUCCESS = 3;
+             }
+             optional string clientUUID = 1;
+             optional int64 timestamp = 2;
+             optional string redirectUri = 3;
+             optional Action action = 4;
+             map<string, ExecutionStatus> executionStatus = 5;
+             optional string protocol = 6;
+             map<string, string> clientNotes = 7;
+             map<string, string> authNotes = 8;
+          }""";
+       ctx.registerProtoFiles(FileDescriptorSource.fromString("keycloak_session.proto", protoDefinition));
+
+       final String json = """
+          {
+             "_type": "RootAuthenticationSessionEntity",
+             "realmId": "83e700f0-1049-4075-a228-155d2869d4a6",
+             "id": "CAksZ3AQD1xfTZRECAP5x1aF",
+             "timestamp": 1788826800,
+             "authenticationSessions": {
+                "rNQe4Of_sQM": {
+                   "clientUUID": "c0d44283-b7e1-4f4c-9d34-d07d4309d0a0",
+                   "timestamp": 1788826800,
+                   "redirectUri": "http://localhost:8080/admin/master/console/",
+                   "action": "AUTHENTICATE",
+                   "executionStatus": {
+                      "b7c18297-aa4d-401f-909e-e1117ffff85c": "CHALLENGED",
+                      "a350caca-652e-4e76-956d-9625159bb45f": "ATTEMPTED"
+                   },
+                   "protocol": "openid-connect",
+                   "clientNotes": {
+                      "scope": "openid"
+                   },
+                   "authNotes": {
+                      "auth_type": "code"
+                   }
+                }
+             }
+          }""";
+       byte[] protobuf = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
+       String converted = ProtobufUtil.toCanonicalJSON(ctx, protobuf);
+       assertValid(converted);
+       assertEquals(json.replaceAll("[\\s\\n]+", ""), converted);
+    }
+
+    @Test
+    public void testMapWithMultipleNestedObjectValues() throws Exception {
+       SerializationContext ctx = ProtobufUtil.newSerializationContext();
+       final String protoDefinition = """
+          syntax = "proto2";
+          message RootAuthenticationSessionEntity {
+             optional string realmId = 1;
+             map<string, AuthenticationSession> authenticationSessions = 2;
+          }
+          message AuthenticationSession {
+             enum ExecutionStatus {
+                CHALLENGED = 1;
+                ATTEMPTED = 2;
+             }
+             optional string clientUUID = 1;
+             optional int64 timestamp = 2;
+             map<string, ExecutionStatus> executionStatus = 3;
+          }""";
+       ctx.registerProtoFiles(FileDescriptorSource.fromString("keycloak_sessions.proto", protoDefinition));
+
+       final String json = """
+          {
+             "_type": "RootAuthenticationSessionEntity",
+             "realmId": "83e700f0-1049-4075-a228-155d2869d4a6",
+             "authenticationSessions": {
+                "rNQe4Of_sQM": {
+                   "clientUUID": "c0d44283-b7e1-4f4c-9d34-d07d4309d0a0",
+                   "timestamp": 1788826800,
+                   "executionStatus": {
+                      "b7c18297-aa4d-401f-909e-e1117ffff85c": "CHALLENGED"
+                   }
+                },
+                "anotherSession": {
+                   "clientUUID": "a1c05359-e57b-492b-8b5c-9e4ba82e94a2",
+                   "timestamp": 1788826900,
+                   "executionStatus": {
+                      "a350caca-652e-4e76-956d-9625159bb45f": "ATTEMPTED"
+                   }
+                }
+             }
+          }""";
+       byte[] protobuf = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
+       String converted = ProtobufUtil.toCanonicalJSON(ctx, protobuf);
+       assertValid(converted);
+       assertEquals(json.replaceAll("[\\s\\n]+", ""), converted);
+    }
+
+    @Test
+    public void testStructuredObject() throws IOException {
       SerializationContext ctx = ProtobufUtil.newSerializationContext();
       final String protoDefinition = """
          syntax = "proto2";
@@ -1168,13 +1278,39 @@ public class ProtobufUtilTest extends AbstractProtoStreamTest {
       assertThrows(IllegalArgumentException.class, () -> ProtobufUtil.fromByteArray(ctx, bytes, Account.Currency.class));
    }
 
-   @Test
-   public void testEstimateSize() throws Exception {
-      ImmutableSerializationContext ctx = createContext();
-      Account account = createAccount();
+    @Test
+    public void testEstimateSize() throws Exception {
+       ImmutableSerializationContext ctx = createContext();
+       Account account = createAccount();
 
-      int estimated = ProtobufUtil.estimateSize(ctx, account);
-      int actual = ProtobufUtil.toByteArray(ctx, account).length;
-      assertTrue(estimated >= actual, "Estimated size " + estimated + " should be >= actual " + actual);
-   }
+       int estimated = ProtobufUtil.estimateSize(ctx, account);
+       int actual = ProtobufUtil.toByteArray(ctx, account).length;
+       assertTrue(estimated >= actual, "Estimated size " + estimated + " should be >= actual " + actual);
+    }
+
+    @Test
+    public void testRepeatedFieldFirstInObject() throws Exception {
+       SerializationContext ctx = ProtobufUtil.newSerializationContext();
+       final String protoDefinition = """
+          syntax = "proto2";
+          message Outer {
+              optional string name=1;
+              optional Inner inner=2;
+          }
+          message Inner {
+              repeated string tags=1;
+          }""";
+       ctx.registerProtoFiles(FileDescriptorSource.fromString("repeated_first.proto", protoDefinition));
+
+       final String json = """
+          {
+             "_type": "Outer",
+             "name": "a",
+             "inner": {"tags": ["x","y"]}
+          }""";
+       byte[] protobuf = ProtobufUtil.fromCanonicalJSON(ctx, new StringReader(json));
+       String converted = ProtobufUtil.toCanonicalJSON(ctx, protobuf);
+       assertValid(converted);
+       assertEquals(json.replaceAll("[\\s\\n]+", ""), converted);
+    }
 }


### PR DESCRIPTION
Fixes #738

- MapJsonWriter: delegate nested structures inside map value messages instead of throwing IllegalStateException
- ArrayJsonWriter: write property name when repeated field is first in an object (lastToken is open brace)

Created with the assistance of an AI tool